### PR TITLE
MODDICONV-117: Remove unnecessary id indexes

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/util/DaoUtil.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/util/DaoUtil.java
@@ -48,6 +48,10 @@ public class DaoUtil {
    * @return - Criteria object
    */
   public static Criteria constructCriteria(String jsonbField, String value) {
+    if ("'id'".equals(jsonbField)) {
+      // for best performance use primary key table.id, not table.jsonb->>'id'
+      return new Criteria().addField("id").setJSONB(false).setOperation("=").setVal(value);
+    }
     Criteria criteria = new Criteria();
     criteria.addField(jsonbField);
     criteria.setOperation("=");

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -3,87 +3,27 @@
     {
       "tableName": "job_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
-      "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ]
+      "withMetadata": true
     },
     {
       "tableName": "match_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
-      "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ]
+      "withMetadata": true
     },
     {
       "tableName": "action_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
-      "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ]
+      "withMetadata": true
     },
     {
       "tableName": "mapping_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
-      "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ]
+      "withMetadata": true
     },
     {
       "tableName": "job_to_match_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -101,18 +41,6 @@
       "tableName": "job_to_action_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -130,18 +58,6 @@
       "tableName": "match_to_match_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -159,18 +75,6 @@
       "tableName": "match_to_action_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -188,18 +92,6 @@
       "tableName": "action_to_action_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -217,18 +109,6 @@
       "tableName": "action_to_match_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -246,18 +126,6 @@
       "tableName": "action_to_mapping_profiles",
       "fromModuleVersion": "mod-data-import-converter-storage-1.7.0",
       "withMetadata": true,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
-      "uniqueIndex": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ],
       "foreignKeys": [
         {
           "fieldName": "masterProfileId",
@@ -274,13 +142,7 @@
     {
       "tableName": "profile_snapshots",
       "fromModuleVersion": "mod-data-import-converter-storage-1.1.0",
-      "withMetadata": false,
-      "index": [
-        {
-          "fieldName": "id",
-          "tOps": "ADD"
-        }
-      ]
+      "withMetadata": false
     },
     {
       "tableName": "forms_configs",


### PR DESCRIPTION
The foreign keys use the PRIMARY KEY id.

"The PRIMARY KEY constraint specifies that a column or columns of a
table can contain only unique (non-duplicate), nonnull values."
(quote from https://www.postgresql.org/docs/current/sql-createtable.html ).

There is no need to create an index or a unique index for jsonb->>'id'
because it will never be used.
"Remove each foreign key field index and each primary key field id index
and uniqueIndex" (quote from the upgrading guide
https://github.com/folio-org/raml-module-builder/blob/master/doc/upgrading.md#version-271 )

v1.7.2 was released without MODDICONV-117.

TODO:

As a consequence additional development effort is needed to delete all the indexes that were created - delete each foreign key field index and each primary key field id index and uniqueIndex.
Ensure (test) that this deletion task runs for each upgrade path:
* v1.7.2 to latest Fameflower release
* v1.7.2 to Goldenrod release
* v1.7.2 to all other later releases