### PR TITLE
MODDICONV-187 Store MARC Authority record

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -29,6 +29,7 @@ public class ModTenantAPI extends TenantAPI {
   private static final String DEFAULT_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_instance_and_marc_bib_create_job_profile.sql";
   private static final String DEFAULT_EDIFACT_MAPPING_PROFILES = "templates/db_scripts/defaultData/default_edifact_mapping_profiles.sql";
   private static final String DEFAULT_MARC_AUTHORITY_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_marc_authority_job_profile.sql";
+  private static final String UPDATE_DATA_TYPES = "templates/db_scripts/data-migration/update_data_types.sql";
   private static final String TENANT_PLACEHOLDER = "${myuniversity}";
   private static final String MODULE_PLACEHOLDER = "${mymodule}";
 
@@ -44,6 +45,7 @@ public class ModTenantAPI extends TenantAPI {
         .compose(m -> setupDefaultData(DEFAULT_EDIFACT_MAPPING_PROFILES, headers, context))
         .compose(m -> setupDefaultData(DEFAULT_MARC_AUTHORITY_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> setupDefaultData(UPDATE_DEFAULT_QM_INSTANCE_AND_SRS_MARC_BIB_CREATE_JOB_PROFILE, headers, context))
+        .compose(m -> setupDefaultData(UPDATE_DATA_TYPES, headers, context))
         .map(num));
   }
 

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/update_data_types.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/update_data_types.sql
@@ -1,0 +1,11 @@
+-- job_profiles:
+-- change values: from MARC to MARC_BIB
+UPDATE ${myuniversity}_${mymodule}.job_profiles
+SET jsonb = jsonb_set(jsonb, '{dataType}', '"MARC_BIB"')
+WHERE jsonb ->> 'dataType' IN ('MARC');
+
+-- job_profiles:
+-- change values: from MARC to MARC_AUTHORITY for default marc authority job
+UPDATE ${myuniversity}_${mymodule}.job_profiles
+SET jsonb = jsonb_set(jsonb, '{dataType}', '"MARC_AUTHORITY"')
+WHERE jsonb ->> 'id' = '6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3';

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -207,6 +207,11 @@
       "run": "after",
       "snippetPath": "data-migration/update_action_types.sql",
       "fromModuleVersion": "mod-data-import-converter-storage-1.9.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/update_data_types.sql",
+      "fromModuleVersion": "mod-data-import-converter-storage-1.11.0"
     }
   ]
 }

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
@@ -37,6 +37,6 @@ public class DefaultJobProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK).extract().as(JobProfile.class);
     Assert.assertEquals( "Default - Create SRS MARC Authority", profile.getName());
-    Assert.assertEquals( JobProfile.DataType.MARC, profile.getDataType());
+    Assert.assertEquals( JobProfile.DataType.MARC_AUTHORITY, profile.getDataType());
   }
 }

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -36,7 +36,7 @@ import static org.folio.rest.impl.MatchProfileTest.MATCH_PROFILES_TABLE_NAME;
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
 import static org.folio.rest.jaxrs.model.JobProfile.DataType.DELIMITED;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
@@ -64,15 +64,15 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   static JobProfileUpdateDto jobProfile_1 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Bla")
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum", "dolor")))
-      .withDataType(MARC));
+      .withDataType(MARC_BIB));
   static JobProfileUpdateDto jobProfile_2 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Boo")
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum")))
-      .withDataType(MARC));
+      .withDataType(MARC_BIB));
   static JobProfileUpdateDto jobProfile_3 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Foo")
       .withTags(new Tags().withTagList(Collections.singletonList("lorem")))
-      .withDataType(MARC));
+      .withDataType(MARC_BIB));
 
   private static final String OCLC_DEFAULT_JOB_PROFILE_ID = "d0ebb7b0-2f0f-11eb-adc1-0242ac120002";
 
@@ -240,7 +240,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   public void shouldReturnBadRequestOnPostJobProfileWithInvalidField() {
     JsonObject jobProfile = new JsonObject()
       .put("name", "Bla")
-      .put("dataType", MARC)
+      .put("dataType", MARC_BIB)
       .put("invalidField", "value");
 
     RestAssured.given()
@@ -482,7 +482,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
 
     JobProfile newJobProfile = new JobProfile()
       .withName("Boo")
-      .withDataType(MARC)
+      .withDataType(MARC_BIB)
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum")));
     Response createResponse = RestAssured.given()
       .spec(spec)
@@ -508,7 +508,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)
       .body(new JobProfileUpdateDto().withProfile(new JobProfile().withName("ProfileToDelete")
-        .withDataType(MARC)))
+        .withDataType(MARC_BIB)))
       .when()
       .post(JOB_PROFILES_PATH)
       .then()
@@ -540,7 +540,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)
       .body(new JobProfileUpdateDto().withProfile(new JobProfile().withName("ProfileToDelete")
-        .withDataType(MARC)))
+        .withDataType(MARC_BIB)))
       .when()
       .post(JOB_PROFILES_PATH)
       .then()
@@ -569,7 +569,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   @Test
   public void shouldCreateProfileOnPostWhenWasDeletedProfileWithSameNameBefore() {
     JobProfile jobProfile = new JobProfile().withName("profileName")
-      .withDataType(MARC);
+      .withDataType(MARC_BIB);
 
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
@@ -69,11 +69,11 @@ public class CommonProfileAssociationTest extends AbstractRestVerticleTest {
   private static final String MASTERS_BY_DETAIL_URL = "/data-import-profiles/profileAssociations/{detailId}/masters";
 
   JobProfileUpdateDto jobProfile1 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC_BIB).withDescription("test-description"));
   JobProfileUpdateDto jobProfile2 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC_BIB).withDescription("test-description"));
   JobProfileUpdateDto jobProfile3 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile3").withDataType(MARC));
+    .withProfile(new JobProfile().withName("testJobProfile3").withDataType(MARC_BIB));
 
   ActionProfileUpdateDto actionProfile1 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile1").withDescription("test-description")

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/snapshot/JobProfileSnapshotTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/snapshot/JobProfileSnapshotTest.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
 import static org.folio.rest.jaxrs.model.ProfileAssociation.ReactTo.MATCH;
 import static org.folio.rest.jaxrs.model.ProfileAssociation.ReactTo.NON_MATCH;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
@@ -67,7 +67,7 @@ public class JobProfileSnapshotTest extends AbstractRestVerticleTest {
 
 
   private JobProfileUpdateDto jobProfile = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC_BIB).withDescription("test-description"));
 
   private MatchProfileUpdateDto matchProfile = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile1")
@@ -278,7 +278,7 @@ public class JobProfileSnapshotTest extends AbstractRestVerticleTest {
     actionProfile2 = postProfile(testContext, actionProfile2, ACTION_PROFILES_PATH).body().as(ActionProfileUpdateDto.class);
 
     JobProfileUpdateDto jobProfile2 = new JobProfileUpdateDto()
-      .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC).withDescription("test-description"))
+      .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC_BIB).withDescription("test-description"))
       .withAddedRelations(Arrays.asList(
         new ProfileAssociation()
           .withDetailProfileId(matchProfile.getId())


### PR DESCRIPTION
## Purpose
Change record type MARC for more specific type, like MARC_BIB, MARC_AUTHORITY, MARC_HOLDING

## Approach
- created script for migration data type from marc to marc_bib
- updated tests
- pull raml storage with new values for data types

## Learning
[MODDICONV-187](https://issues.folio.org/browse/MODDICONV-187)


