### PR TITLE
fix: blocked mirror for repositories: indexdata

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -2,7 +2,7 @@ stages:
 - name: Build
   steps:
   - runScriptConfig:
-      image: maven:3-adoptopenjdk-11
+      image: maven:3.6.3-openjdk-11
       shellScript: mvn package -DskipTests -Djava.util.logging.config.file=vertx-default-jul-logging.properties
 - name: Build Docker with DIND
   steps:


### PR DESCRIPTION
## Purpose
Blocked mirror for repositories: [indexdata (http://maven.indexdata.com/, default, releases+snapshots)]

## Approach
This problem is related to the maven version you are using in your pipeline, it seems that it doesnt accept http url for downloading dependencies, to solve this problem , you should change the docker image you are using to : maven:3.6.3-openjdk-11 and the pipeline will run successfully.