### PR TITLE
MODDICONV-191 - Change dataType to have have common type for MARC related subtypes

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -9,18 +9,18 @@ stages:
   - publishImageConfig:
       dockerfilePath: ./Dockerfile
       buildContext: .
-      tag: docker.dev.folio.org/mod-data-import-converter-storage:folijet-${CICD_EXECUTION_SEQUENCE}
+      tag: docker.dev.folio.org/mod-data-import-converter-storage:spitfire-${CICD_EXECUTION_SEQUENCE}
       pushRemote: true
       registry: docker.dev.folio.org
 - name: Deploy
   steps:
   - applyAppConfig:
-      catalogTemplate: p-gh7sb:folijet-helmcharts-mod-data-import-converter-storage
+      catalogTemplate: p-htqfq:spitfire-helmcharts-mod-data-import-converter-storage
       version: 0.1.32
       answers:
         image.repository: docker.dev.folio.org/mod-data-import-converter-storage
-        image.tag: folijet-${CICD_EXECUTION_SEQUENCE}
-      targetNamespace: folijet
+        image.tag: spitfire-${CICD_EXECUTION_SEQUENCE}
+      targetNamespace: spitfire
       name: mod-data-import-converter-storage
 timeout: 60
 notification: {}

--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -9,18 +9,18 @@ stages:
   - publishImageConfig:
       dockerfilePath: ./Dockerfile
       buildContext: .
-      tag: docker.dev.folio.org/mod-data-import-converter-storage:spitfire-${CICD_EXECUTION_SEQUENCE}
+      tag: docker.dev.folio.org/mod-data-import-converter-storage:folijet-${CICD_EXECUTION_SEQUENCE}
       pushRemote: true
       registry: docker.dev.folio.org
 - name: Deploy
   steps:
   - applyAppConfig:
-      catalogTemplate: p-htqfq:spitfire-helmcharts-mod-data-import-converter-storage
+      catalogTemplate: p-gh7sb:folijet-helmcharts-mod-data-import-converter-storage
       version: 0.1.32
       answers:
         image.repository: docker.dev.folio.org/mod-data-import-converter-storage
-        image.tag: spitfire-${CICD_EXECUTION_SEQUENCE}
-      targetNamespace: spitfire
+        image.tag: folijet-${CICD_EXECUTION_SEQUENCE}
+      targetNamespace: folijet
       name: mod-data-import-converter-storage
 timeout: 60
 notification: {}

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -29,7 +29,6 @@ public class ModTenantAPI extends TenantAPI {
   private static final String DEFAULT_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_instance_and_marc_bib_create_job_profile.sql";
   private static final String DEFAULT_EDIFACT_MAPPING_PROFILES = "templates/db_scripts/defaultData/default_edifact_mapping_profiles.sql";
   private static final String DEFAULT_MARC_AUTHORITY_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_marc_authority_job_profile.sql";
-  private static final String UPDATE_DATA_TYPES = "templates/db_scripts/data-migration/update_data_types.sql";
   private static final String TENANT_PLACEHOLDER = "${myuniversity}";
   private static final String MODULE_PLACEHOLDER = "${mymodule}";
 
@@ -45,7 +44,6 @@ public class ModTenantAPI extends TenantAPI {
         .compose(m -> setupDefaultData(DEFAULT_EDIFACT_MAPPING_PROFILES, headers, context))
         .compose(m -> setupDefaultData(DEFAULT_MARC_AUTHORITY_CREATE_JOB_PROFILE, headers, context))
         .compose(m -> setupDefaultData(UPDATE_DEFAULT_QM_INSTANCE_AND_SRS_MARC_BIB_CREATE_JOB_PROFILE, headers, context))
-        .compose(m -> setupDefaultData(UPDATE_DATA_TYPES, headers, context))
         .map(num));
   }
 

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/return_data_types.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/data-migration/return_data_types.sql
@@ -1,0 +1,5 @@
+-- job_profiles:
+-- revert change values: from MARC_BIB to MARC
+UPDATE ${myuniversity}_${mymodule}.job_profiles
+SET jsonb = jsonb_set(jsonb, '{dataType}', '"MARC"')
+WHERE jsonb ->> 'dataType' IN ('MARC_BIB', 'MARC_AUTHORITY');

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -212,6 +212,11 @@
       "run": "after",
       "snippetPath": "data-migration/update_data_types.sql",
       "fromModuleVersion": "mod-data-import-converter-storage-1.11.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "data-migration/return_data_types.sql",
+      "fromModuleVersion": "mod-data-import-converter-storage-1.11.0"
     }
   ]
 }

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -216,7 +216,7 @@
     {
       "run": "after",
       "snippetPath": "data-migration/return_data_types.sql",
-      "fromModuleVersion": "mod-data-import-converter-storage-1.11.0"
+      "fromModuleVersion": "mod-data-import-converter-storage-1.12.0"
     }
   ]
 }

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
@@ -37,6 +37,6 @@ public class DefaultJobProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK).extract().as(JobProfile.class);
     Assert.assertEquals( "Default - Create SRS MARC Authority", profile.getName());
-    Assert.assertEquals( JobProfile.DataType.MARC_AUTHORITY, profile.getDataType());
+    Assert.assertEquals( JobProfile.DataType.MARC, profile.getDataType());
   }
 }

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -35,8 +35,7 @@ import static org.folio.rest.impl.MatchProfileTest.MATCH_PROFILES_PATH;
 import static org.folio.rest.impl.MatchProfileTest.MATCH_PROFILES_TABLE_NAME;
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.DELIMITED;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.*;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MATCH_PROFILE;
@@ -64,15 +63,15 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   static JobProfileUpdateDto jobProfile_1 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Bla")
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum", "dolor")))
-      .withDataType(MARC_BIB));
+      .withDataType(MARC));
   static JobProfileUpdateDto jobProfile_2 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Boo")
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum")))
-      .withDataType(MARC_BIB));
+      .withDataType(MARC));
   static JobProfileUpdateDto jobProfile_3 = new JobProfileUpdateDto()
     .withProfile(new JobProfile().withName("Foo")
       .withTags(new Tags().withTagList(Collections.singletonList("lorem")))
-      .withDataType(MARC_BIB));
+      .withDataType(MARC));
 
   private static final String OCLC_DEFAULT_JOB_PROFILE_ID = "d0ebb7b0-2f0f-11eb-adc1-0242ac120002";
 
@@ -240,7 +239,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   public void shouldReturnBadRequestOnPostJobProfileWithInvalidField() {
     JsonObject jobProfile = new JsonObject()
       .put("name", "Bla")
-      .put("dataType", MARC_BIB)
+      .put("dataType", MARC)
       .put("invalidField", "value");
 
     RestAssured.given()
@@ -482,7 +481,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
 
     JobProfile newJobProfile = new JobProfile()
       .withName("Boo")
-      .withDataType(MARC_BIB)
+      .withDataType(MARC)
       .withTags(new Tags().withTagList(Arrays.asList("lorem", "ipsum")));
     Response createResponse = RestAssured.given()
       .spec(spec)
@@ -508,7 +507,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)
       .body(new JobProfileUpdateDto().withProfile(new JobProfile().withName("ProfileToDelete")
-        .withDataType(MARC_BIB)))
+        .withDataType(MARC)))
       .when()
       .post(JOB_PROFILES_PATH)
       .then()
@@ -540,7 +539,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)
       .body(new JobProfileUpdateDto().withProfile(new JobProfile().withName("ProfileToDelete")
-        .withDataType(MARC_BIB)))
+        .withDataType(MARC)))
       .when()
       .post(JOB_PROFILES_PATH)
       .then()
@@ -569,7 +568,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
   @Test
   public void shouldCreateProfileOnPostWhenWasDeletedProfileWithSameNameBefore() {
     JobProfile jobProfile = new JobProfile().withName("profileName")
-      .withDataType(MARC_BIB);
+      .withDataType(MARC);
 
     JobProfileUpdateDto jobProfileToDelete = RestAssured.given()
       .spec(spec)

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/association/CommonProfileAssociationTest.java
@@ -36,7 +36,7 @@ import java.util.UUID;
 
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.JOB_PROFILE;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.MAPPING_PROFILE;
@@ -69,11 +69,11 @@ public class CommonProfileAssociationTest extends AbstractRestVerticleTest {
   private static final String MASTERS_BY_DETAIL_URL = "/data-import-profiles/profileAssociations/{detailId}/masters";
 
   JobProfileUpdateDto jobProfile1 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC_BIB).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC).withDescription("test-description"));
   JobProfileUpdateDto jobProfile2 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC_BIB).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC).withDescription("test-description"));
   JobProfileUpdateDto jobProfile3 = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile3").withDataType(MARC_BIB));
+    .withProfile(new JobProfile().withName("testJobProfile3").withDataType(MARC));
 
   ActionProfileUpdateDto actionProfile1 = new ActionProfileUpdateDto()
     .withProfile(new ActionProfile().withName("testActionProfile1").withDescription("test-description")

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/snapshot/JobProfileSnapshotTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/snapshot/JobProfileSnapshotTest.java
@@ -34,7 +34,7 @@ import java.util.UUID;
 
 import static org.folio.rest.jaxrs.model.ActionProfile.Action.CREATE;
 import static org.folio.rest.jaxrs.model.ActionProfile.FolioRecord.MARC_BIBLIOGRAPHIC;
-import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC_BIB;
+import static org.folio.rest.jaxrs.model.JobProfile.DataType.MARC;
 import static org.folio.rest.jaxrs.model.ProfileAssociation.ReactTo.MATCH;
 import static org.folio.rest.jaxrs.model.ProfileAssociation.ReactTo.NON_MATCH;
 import static org.folio.rest.jaxrs.model.ProfileSnapshotWrapper.ContentType.ACTION_PROFILE;
@@ -67,7 +67,7 @@ public class JobProfileSnapshotTest extends AbstractRestVerticleTest {
 
 
   private JobProfileUpdateDto jobProfile = new JobProfileUpdateDto()
-    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC_BIB).withDescription("test-description"));
+    .withProfile(new JobProfile().withName("testJobProfile1").withDataType(MARC).withDescription("test-description"));
 
   private MatchProfileUpdateDto matchProfile = new MatchProfileUpdateDto()
     .withProfile(new MatchProfile().withName("testMatchProfile1")
@@ -278,7 +278,7 @@ public class JobProfileSnapshotTest extends AbstractRestVerticleTest {
     actionProfile2 = postProfile(testContext, actionProfile2, ACTION_PROFILES_PATH).body().as(ActionProfileUpdateDto.class);
 
     JobProfileUpdateDto jobProfile2 = new JobProfileUpdateDto()
-      .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC_BIB).withDescription("test-description"))
+      .withProfile(new JobProfile().withName("testJobProfile2").withDataType(MARC).withDescription("test-description"))
       .withAddedRelations(Arrays.asList(
         new ProfileAssociation()
           .withDetailProfileId(matchProfile.getId())


### PR DESCRIPTION
## Purpose
reverting data type changes to generic MARC according to the https://issues.folio.org/browse/MODDICONV-191

## Approach

- changed back data type to generic MARC
- fixed tests
