### PR TITLE
MODDICONV-199 - Add default mapping profile to default Holdings profile

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 2021-XX-XX v1.12.0-SNAPSHOT
 * [MODDICONV-196](https://issues.folio.org/browse/MODDICONV-196) Upgrade to RAML Module Builder 33.x
+* [MODDICONV-199](https://issues.folio.org/browse/MODDICONV-199) MODDICONV-199 - Add default mapping profile to default Holdings profile
 
 ## 2021-XX-XX v1.11.2-SNAPSHOT
 * [MODDICONV-192](https://issues.folio.org/browse/MODDICONV-192) Disallow linking multiple mapping profiles to one action profile

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_marc_holdings_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_marc_holdings_job_profile.sql
@@ -21,4 +21,279 @@ INSERT INTO ${myuniversity}_${mymodule}.job_profiles (id, jsonb) values
     "createdByUserId": "00000000-0000-0000-0000-000000000000",
     "updatedByUserId": "00000000-0000-0000-0000-000000000000"
   }
-}') ON CONFLICT DO NOTHING;
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO ${myuniversity}_${mymodule}.action_profiles (id, jsonb) values
+('8aa0b850-9182-4005-8435-340b704b2a19', '{
+  "id": "8aa0b850-9182-4005-8435-340b704b2a19",
+  "name": "Default - Create Holdings",
+  "action": "CREATE",
+  "deleted": false,
+  "description": "This action profile is used with FOLIO''s default job profile for creating Inventory Holdings and SRS MARC Holdings records. It can be edited, duplicated.",
+  "folioRecord": "HOLDINGS",
+  "childProfiles": [],
+  "parentProfiles": [],
+    "metadata": {
+      "createdDate": "2021-08-05T14:00:00.000",
+      "updatedDate": "2021-08-05T15:00:00.462+0000",
+      "createdByUserId": "00000000-0000-0000-0000-000000000000",
+      "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+    },
+    "userInfo": {
+      "lastName": "System",
+      "userName": "System",
+      "firstName": "System"
+    }
+}')
+ON CONFLICT DO NOTHING;
+
+
+INSERT INTO ${myuniversity}_${mymodule}.mapping_profiles (id, jsonb) values
+('13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a', '{
+  "id": "13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a",
+  "name": "Default - Create holdings",
+  "deleted": false,
+  "metadata": {
+    "createdDate": "2021-08-05T14:00:00.000",
+    "updatedDate": "2021-08-05T15:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "description": "This field mapping profile is used with FOLIO''s default job profile for creating Inventory Holdings and SRS MARC Holdings records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
+  "childProfiles": [],
+  "mappingDetails": {
+    "name": "holdings",
+    "recordType": "HOLDINGS",
+    "mappingFields": [
+      {
+        "name": "hrid",
+        "path": "holdings.hrid",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsTypeId",
+        "path": "holdings.holdingsTypeId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "discoverySuppress",
+        "path": "holdings.discoverySuppress",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "formerIds",
+        "path": "holdings.formerIds",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "instanceId",
+        "path": "holdings.instanceId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "permanentLocationId",
+        "path": "holdings.permanentLocationId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "temporaryLocationId",
+        "path": "holdings.temporaryLocationId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "effectiveLocationId",
+        "path": "holdings.effectiveLocationId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "callNumberTypeId",
+        "path": "holdings.callNumberTypeId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "callNumberPrefix",
+        "path": "holdings.callNumberPrefix",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "callNumber",
+        "path": "holdings.callNumber",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "callNumberSuffix",
+        "path": "holdings.callNumberSuffix",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "shelvingTitle",
+        "path": "holdings.shelvingTitle",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "acquisitionFormat",
+        "path": "holdings.acquisitionFormat",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "acquisitionMethod",
+        "path": "holdings.acquisitionMethod",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "receiptStatus",
+        "path": "holdings.receiptStatus",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "illPolicyId",
+        "path": "holdings.illPolicyId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "retentionPolicy",
+        "path": "holdings.retentionPolicy",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "digitizationPolicy",
+        "path": "holdings.digitizationPolicy",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "copyNumber",
+        "path": "holdings.copyNumber",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "numberOfItems",
+        "path": "holdings.numberOfItems",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "electronicAccess",
+        "path": "holdings.electronicAccess[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "notes",
+        "path": "holdings.notes[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsStatements",
+        "path": "holdings.holdingsStatements[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsStatementsForIndexes",
+        "path": "holdings.holdingsStatementsForIndexes[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsStatementsForSupplements",
+        "path": "holdings.holdingsStatementsForSupplements[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "receivingHistory",
+        "path": "holdings.receivingHistory",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "statisticalCodeIds",
+        "path": "holdings.statisticalCodeIds[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsItems",
+        "path": "holdings.holdingsItems[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "bareHoldingsItems",
+        "path": "holdings.bareHoldingsItems[]",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "holdingsInstance",
+        "path": "holdings.holdingsInstance",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }, {
+        "name": "sourceId",
+        "path": "holdings.sourceId",
+        "value": "",
+        "enabled": "false",
+        "subfields": []
+      }
+    ],
+    "marcMappingDetails": []
+  },
+  "parentProfiles": [],
+  "existingRecordType": "HOLDINGS",
+  "incomingRecordType": "MARC_HOLDINGS",
+  "marcFieldProtectionSettings": []
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO ${myuniversity}_${mymodule}.job_to_action_profiles (id, jsonb) values
+('866a90ce-53b2-4b7b-afb5-d3a564e5087e', '{
+  "id": "866a90ce-53b2-4b7b-afb5-d3a564e5087e",
+  "order": 0,
+  "triggered": false,
+  "detailProfileId": "8aa0b850-9182-4005-8435-340b704b2a19",
+  "masterProfileId": "80898dee-449f-44dd-9c8e-37d5eb469b1d",
+  "detailProfileType": "ACTION_PROFILE",
+  "masterProfileType": "JOB_PROFILE"
+}')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO ${myuniversity}_${mymodule}.action_to_mapping_profiles (id, jsonb) values
+('8aa0b850-9182-4005-8435-340b704b2a19', '{
+  "id": "8aa0b850-9182-4005-8435-340b704b2a19",
+  "order": 0,
+  "triggered": false,
+  "detailProfileId": "13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a",
+  "masterProfileId": "8aa0b850-9182-4005-8435-340b704b2a19",
+  "detailProfileType": "MAPPING_PROFILE",
+  "masterProfileType": "ACTION_PROFILE"
+}')
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Purpose
In the scope of https://issues.folio.org/browse/MODSOURCE-336 the default mapping is required to create an Inventory Holdings. It is not expected that after this PR is merged user will see created Holdings.  

## Approach
* created default mapping profile for MARC_HOLDINGS
* created action profile for MARC_HOLDINGS
* added linkage between job <-> action profile
* added linkage between action <-> mapping profile

