### PR TITLE
MODDICONV-204. When removing an action profile from a job profile, it sometimes removes that action from ALL job profiles

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 2021-XX-XX v1.12.0-SNAPSHOT
 * [MODDICONV-196](https://issues.folio.org/browse/MODDICONV-196) Upgrade to RAML Module Builder 33.x
 * [MODDICONV-199](https://issues.folio.org/browse/MODDICONV-199) MODDICONV-199 - Add default mapping profile to default Holdings profile
+* [MODDICONV-204](https://issues.folio.org/browse/MODDICONV-204) When removing an action profile from a job profile, it sometimes removes that action from ALL job profiles
 
 ## 2021-XX-XX v1.11.2-SNAPSHOT
 * [MODDICONV-192](https://issues.folio.org/browse/MODDICONV-192) Disallow linking multiple mapping profiles to one action profile

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/association/ProfileAssociationDao.java
@@ -69,14 +69,15 @@ public interface ProfileAssociationDao {
   /**
    * Delete ProfileAssociation  by masterId and detailId
    *
-   * @param masterId   - UUID of masterProfile
-   * @param detailId   - UUID of detailProfile
-   * @param masterType - master Profile Type
-   * @param detailType - detail Profile Type
-   * @param tenantId   - tenant id
+   * @param masterId     - UUID of masterProfile
+   * @param detailId     - UUID of detailProfile
+   * @param masterType   - master Profile Type
+   * @param detailType   - detail Profile Type
+   * @param tenantId     - tenant id
+   * @param jobProfileId - job profile id (optional)
    * @return - boolean result of operation
    */
-  Future<Boolean> delete(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
+  Future<Boolean> delete(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId, String jobProfileId);
 
   /**
    * Delete profile associations for particular master profile by masterId

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -100,7 +100,7 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
     profileAssociations.forEach(association -> futureList.add(profileAssociationService.delete(association.getMasterProfileId(),
       association.getDetailProfileId(),
       ProfileSnapshotWrapper.ContentType.fromValue(association.getMasterProfileType().name()),
-      ProfileSnapshotWrapper.ContentType.fromValue(association.getDetailProfileType().name()), tenantId)));
+      ProfileSnapshotWrapper.ContentType.fromValue(association.getDetailProfileType().name()), tenantId, association.getJobProfileId())));
     GenericCompositeFuture.all(futureList).onComplete(ar -> {
       if (ar.succeeded()) {
         result.complete(true);

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/JobProfileServiceImpl.java
@@ -52,6 +52,11 @@ public class JobProfileServiceImpl extends AbstractProfileService<JobProfile, Jo
         association.setJobProfileId(profileDto.getProfile().getId());
       }
     });
+    profileDto.getDeletedRelations().forEach(association -> {
+      if (association.getMasterProfileType() == MATCH_PROFILE) {
+        association.setJobProfileId(profileDto.getProfile().getId());
+      }
+    });
     return profileDto;
   }
 

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/association/CommonProfileAssociationService.java
@@ -112,8 +112,8 @@ public class CommonProfileAssociationService implements ProfileAssociationServic
   }
 
   @Override
-  public Future<Boolean> delete(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId) {
-    return profileAssociationDao.delete(masterId, detailId, masterType, detailType, tenantId);
+  public Future<Boolean> delete(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId, String jobProfileId) {
+    return profileAssociationDao.delete(masterId, detailId, masterType, detailType, tenantId, jobProfileId);
   }
 
   @Override

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/association/ProfileAssociationService.java
@@ -99,14 +99,15 @@ public interface ProfileAssociationService { //NOSONAR
   /**
    * Delete ProfileAssociation by masterId and detailId
    *
-   * @param masterId   - UUID of masterProfile
-   * @param detailId   - UUID of detailProfile
-   * @param masterType - master Profile Type
-   * @param detailType - detail Profile Type
-   * @param tenantId   - tenant id
+   * @param masterId     - UUID of masterProfile
+   * @param detailId     - UUID of detailProfile
+   * @param masterType   - master Profile Type
+   * @param detailType   - detail Profile Type
+   * @param tenantId     - tenant id
+   * @param jobProfileId - job profile id (optional)
    * @return - boolean result of operation
    */
-  Future<Boolean> delete(String masterId, String detailId, ProfileSnapshotWrapper.ContentType masterType, ProfileSnapshotWrapper.ContentType detailType, String tenantId);
+  Future<Boolean> delete(String masterId, String detailId, ContentType masterType, ContentType detailType, String tenantId, String jobProfileId);
 
   /**
    * Delete profile associations for particular master profile by masterId


### PR DESCRIPTION
## Purpose
When removing an action profile from a job profile, sometimes that will cause that action profile to be removed from all job profiles it is associated with. Need to fix it

## Approach
Table match_to_action_profiles contains field jobExecutionId, that need to be included in delete query to delete only profile associated with particular job execution profile. Also delete sql query should not fail, if  jobExecutionId is not presented in jsonb, because other mapping tables do not contain jobExecutionId
