### PR TITLE
Upgrade to RMB v33.2.1

### DIFF
--- a/mod-data-import-converter-storage-server/pom.xml
+++ b/mod-data-import-converter-storage-server/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.1.0</version>
+      <version>1.4.1</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.0.2</raml-module-builder.version>
-    <vertx.version>4.1.0</vertx.version>
+    <raml-module-builder.version>33.2.1</raml-module-builder.version>
+    <vertx.version>4.2.1</vertx.version>
     <junit.version>4.13</junit.version>
     <mockito.version>3.5.13</mockito.version>
     <rest-assured.version>4.3.3</rest-assured.version>
@@ -39,16 +39,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Upgrades
RMB to 33.2.1 (includes log4j vulnerability fix)
Vert.x  to 4.2.1
folio-di-support to 1.4.1