### PR TITLE
MODDICONV-218 - Juniper R2 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## 2021-12-xx v1.11.4
+* [MODDICONV-218](https://issues.folio.org/browse/MODDICONV-218) Juniper R2 2021 - Log4j vulnerability verification and correction
+
 ## 2021-09-13 v1.11.3
 * [MODDICONV-204](https://issues.folio.org/browse/MODDICONV-204) When removing an action profile from a job profile, it sometimes removes that action from ALL job profiles
 

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,13 @@
         <artifactId>vertx-pg-client</artifactId>
         <version>${vertx.version}-FOLIO</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.16.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
## Purpose
to fix the vulnerability that is present in log4j<= 2.14

## Approach
* upgrade log4j version to 2.16.0

## Learning
[MODDICONV-218](https://issues.folio.org/browse/MODDICONV-218)