### PR TITLE
MODDICONV-234 Suppress MARC Authority Delete profiles from Data Import Settings UI

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/ProfileDao.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/ProfileDao.java
@@ -17,13 +17,14 @@ public interface ProfileDao<T, S> {
    * Searches for T entities in database
    *
    * @param showDeleted indicates to return T entities marked as deleted or not
+   * @param showHidden  indicates to return T entities marked as hidden or not
    * @param query       query from URL
    * @param offset      starting index in a list of results
    * @param limit       limit of records for pagination
    * @param tenantId    tenant id
    * @return future with S, a collection of T entities
    */
-  Future<S> getProfiles(boolean showDeleted, String query, int offset, int limit, String tenantId);
+  Future<S> getProfiles(boolean showDeleted, boolean showHidden, String query, int offset, int limit, String tenantId);
 
   /**
    * Searches for T entity by id

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -149,7 +149,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesJobProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+  public void getDataImportProfilesJobProfiles(boolean showDeleted, boolean showHidden, boolean withRelations,
                                                String query, int offset, int limit, String lang,
                                                Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                                Context vertxContext) {
@@ -270,7 +270,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesMatchProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+  public void getDataImportProfilesMatchProfiles(boolean showDeleted, boolean showHidden, boolean withRelations,
                                                  String query, int offset, int limit, String lang,
                                                  Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                                  Context vertxContext) {
@@ -366,7 +366,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesMappingProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+  public void getDataImportProfilesMappingProfiles(boolean showDeleted, boolean showHidden, boolean withRelations,
                                                    String query, int offset, int limit, String lang,
                                                    Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                                    Context vertxContext) {
@@ -508,7 +508,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesActionProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+  public void getDataImportProfilesActionProfiles(boolean showDeleted, boolean showHidden, boolean withRelations,
                                                   String query, int offset, int limit, String lang,
                                                   Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                                   Context vertxContext) {

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -149,10 +149,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesJobProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getDataImportProfilesJobProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+                                               String query, int offset, int limit, String lang,
+                                               Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                               Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        jobProfileService.getProfiles(showDeleted, withRelations, query, offset, limit, tenantId)
+        jobProfileService.getProfiles(showDeleted, withRelations, showHidden, query, offset, limit, tenantId)
           .map(GetDataImportProfilesJobProfilesResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -267,10 +270,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesMatchProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getDataImportProfilesMatchProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+                                                 String query, int offset, int limit, String lang,
+                                                 Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                                 Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        matchProfileService.getProfiles(showDeleted, withRelations, query, offset, limit, tenantId)
+        matchProfileService.getProfiles(showDeleted, withRelations, showHidden, query, offset, limit, tenantId)
           .map(GetDataImportProfilesMatchProfilesResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -360,10 +366,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesMappingProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getDataImportProfilesMappingProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+                                                   String query, int offset, int limit, String lang,
+                                                   Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                                   Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        mappingProfileService.getProfiles(showDeleted, withRelations, query, offset, limit, tenantId)
+        mappingProfileService.getProfiles(showDeleted, withRelations, showHidden, query, offset, limit, tenantId)
           .map(GetDataImportProfilesMappingProfilesResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)
@@ -499,10 +508,13 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   }
 
   @Override
-  public void getDataImportProfilesActionProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getDataImportProfilesActionProfiles(boolean showDeleted, boolean withRelations, boolean showHidden,
+                                                  String query, int offset, int limit, String lang,
+                                                  Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                                                  Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        actionProfileService.getProfiles(showDeleted, withRelations, query, offset, limit, tenantId)
+        actionProfileService.getProfiles(showDeleted, withRelations, showHidden, query, offset, limit, tenantId)
           .map(GetDataImportProfilesActionProfilesResponse::respond200WithApplicationJson)
           .map(Response.class::cast)
           .otherwise(ExceptionHelper::mapExceptionToResponse)

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/ModTenantAPI.java
@@ -34,6 +34,10 @@ public class ModTenantAPI extends TenantAPI {
   private static final String DEFAULT_UPDATE_MARC_AUTHORITY_JOB_PROFILE = "templates/db_scripts/defaultData/default_update_marc_authority_job_profile.sql";
   private static final String DEFAULT_UPDATE_MARC_HOLDINGS_JOB_PROFILE = "templates/db_scripts/defaultData/default_update_marc_holdings_job_profile.sql";
   private static final String DEFAULT_UPDATE_QM_SRS_MARC_HOLDINGS_JOB_PROFILE = "templates/db_scripts/defaultData/default_update_qm_holdings_and_srs_marc_holdings_create_job_profile.sql";
+  private static final String DEFAULT_UPDATE_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE = "templates/db_scripts/defaultData/default_update_instance_and_marc_bib_create_job_profile.sql";
+  private static final String DEFAULT_UPDATE_OCLC_JOB_PROFILE_SQL = "templates/db_scripts/defaultData/default_update_oclc_job_profile.sql";
+  private static final String DEFAULT_UPDATE_OCLC_UPDATE_JOB_PROFILE_SQL = "templates/db_scripts/defaultData/default_update_oclc_update_job_profile.sql";
+  private static final String DEFAULT_UPDATE_EDIFACT_MAPPING_PROFILES = "templates/db_scripts/defaultData/default_update_edifact_mapping_profiles.sql";
 
   private static final String TENANT_PLACEHOLDER = "${myuniversity}";
   private static final String MODULE_PLACEHOLDER = "${mymodule}";
@@ -55,6 +59,10 @@ public class ModTenantAPI extends TenantAPI {
         .compose(m -> setupDefaultData(DEFAULT_UPDATE_MARC_AUTHORITY_JOB_PROFILE, headers, context))
         .compose(m -> setupDefaultData(DEFAULT_UPDATE_MARC_HOLDINGS_JOB_PROFILE, headers, context))
         .compose(m -> setupDefaultData(DEFAULT_UPDATE_QM_SRS_MARC_HOLDINGS_JOB_PROFILE, headers, context))
+        .compose(m -> setupDefaultData(DEFAULT_UPDATE_INSTANCE_AND_MARC_BIB_CREATE_JOB_PROFILE, headers, context))
+        .compose(m -> setupDefaultData(DEFAULT_UPDATE_OCLC_JOB_PROFILE_SQL, headers, context))
+        .compose(m -> setupDefaultData(DEFAULT_UPDATE_OCLC_UPDATE_JOB_PROFILE_SQL, headers, context))
+        .compose(m -> setupDefaultData(DEFAULT_UPDATE_EDIFACT_MAPPING_PROFILES, headers, context))
         .map(num));
   }
 

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/AbstractProfileService.java
@@ -59,8 +59,8 @@ public abstract class AbstractProfileService<T, S, D> implements ProfileService<
   protected CommonProfileAssociationService associationService;
 
   @Override
-  public Future<S> getProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String tenantId) {
-    return profileDao.getProfiles(showDeleted, query, offset, limit, tenantId)
+  public Future<S> getProfiles(boolean showDeleted, boolean withRelations, boolean showHidden, String query, int offset, int limit, String tenantId) {
+    return profileDao.getProfiles(showDeleted, showHidden, query, offset, limit, tenantId)
       .compose(profilesCollection -> {
         if (withRelations) {
           return fetchRelationsForCollection(profilesCollection, tenantId);

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -18,6 +18,7 @@ public interface ProfileService<T, S, D> {
    * Searches for T entities
    *
    * @param showDeleted   indicates to return T entities marked as deleted or not
+   * @param showHidden    indicates to return T entities marked as hidden or not
    * @param query         query from URL
    * @param offset        starting index in a list of results
    * @param limit         limit of records for pagination
@@ -25,7 +26,7 @@ public interface ProfileService<T, S, D> {
    * @param tenantId      tenant id
    * @return future with S, a collection of T entities
    */
-  Future<S> getProfiles(boolean showDeleted, boolean withRelations, String query, int offset, int limit, String tenantId);
+  Future<S> getProfiles(boolean showDeleted, boolean withRelations, boolean showHidden, String query, int offset, int limit, String tenantId);
 
   /**
    * Searches for T by id

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_edifact_mapping_profiles.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_edifact_mapping_profiles.sql
@@ -1,0 +1,4447 @@
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "2ad182ee-75e8-4bdb-b859-530543a064dc",
+  "name": "Default - GOBI monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for GOBI. Edit to add details specific to your library and invoices. If additional GOBI invoice profiles are needed, duplicate this one. If no GOBI invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-01-14T14:00:00.000",
+    "updatedDate": "2021-01-14T15:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SLI[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '2ad182ee-75e8-4bdb-b859-530543a064dc';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "c89cf275-3ebf-4271-ae89-343dd5824d75",
+  "name": "Default - EBSCO serials invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for EBSCO. Edit to add details specific to your library and invoices. If additional EBSCO invoice profiles are needed, duplicate this one. If no EBSCO invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T14:00:00.000",
+    "updatedDate": "2021-03-01T15:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SNA[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "DTM+194[2]",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "DTM+206[2]",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = 'c89cf275-3ebf-4271-ae89-343dd5824d75';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "7bfd8670-b3f1-447c-ac43-29e04324809c",
+  "name": "Default - WT Cox serials invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for WT Cox. Edit to add details specific to your library and invoices. If additional WT Cox invoice profiles are needed, duplicate this one. If no WT Cox invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T14:00:00.000",
+    "updatedDate": "2021-03-01T15:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SNA[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "DTM+194[2]",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "DTM+206[2]",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '7bfd8670-b3f1-447c-ac43-29e04324809c';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "5c117edc-4f1a-4395-9a9f-ea48f28798d5",
+  "name": "Default - Harrassowitz serials invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Harrassowitz. Edit to add details specific to your library and invoices. If additional Harrassowitz invoice profiles are needed, duplicate this one. If no Harrassowitz invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T14:00:00.000",
+    "updatedDate": "2021-03-01T15:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+F+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+SNL[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SNA[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '5c117edc-4f1a-4395-9a9f-ea48f28798d5';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "fedf651c-5287-4775-9bc4-dd2460df97e3",
+  "name": "Default - Amalivre monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Amalivre. Edit to add details specific to your library and invoices. If additional Amalivre invoice profiles are needed, duplicate this one. If no Amalivre invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+8?4[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2+3[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+F+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+SNL[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203?4[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = 'fedf651c-5287-4775-9bc4-dd2460df97e3';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "7a5b35cf-d574-4f1e-9610-b429372f8140",
+  "name": "Default - Casalini monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Casalini. Edit to add details specific to your library and invoices. If additional Casalini invoice profiles are needed, duplicate this one. If no Casalini invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+86[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SNA[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "PRI+AAB[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '7a5b35cf-d574-4f1e-9610-b429372f8140';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "8f7e326f-326f-471f-88c2-724ee8e3b2e9",
+  "name": "Default - CNPIEC monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for CNPIEC. Edit to add details specific to your library and invoices. If additional CNPIEC invoice profiles are needed, duplicate this one. If no CNPIEC invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else PIA+5+?IB[1]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "PIA+1+[1]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '8f7e326f-326f-471f-88c2-724ee8e3b2e9';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "fd351093-8df0-4f4e-b202-32ca5a0f00c6",
+  "name": "Default - Coutts monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Coutts. Edit to add details specific to your library and invoices. If additional Coutts invoice profiles are needed, duplicate this one. If no Coutts invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "PRI+AAB[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = 'fd351093-8df0-4f4e-b202-32ca5a0f00c6';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "6cdd60de-b8c1-41ce-ab57-6684d5a18fad",
+  "name": "Default - Erasmus monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Erasmus. Edit to add details specific to your library and invoices. If additional Erasmus invoice profiles are needed, duplicate this one. If no Erasmus invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+86[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD++050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '6cdd60de-b8c1-41ce-ab57-6684d5a18fad';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "4f8505ce-59c8-42f1-b925-b1e57d8f9269",
+  "name": "Default - Hein serials invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Hein. Edit to add details specific to your library and invoices. If additional Hein invoice profiles are needed, duplicate this one. If no Hein invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM<137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA<86[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM<380<[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX<2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD<F<JTI<[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF<ON[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "PIA<5<?SA[1]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY<47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA<203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '4f8505ce-59c8-42f1-b925-b1e57d8f9269';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "950d9436-6a96-40f6-94c8-9ae39aef26e4",
+  "name": "Default - Midwest monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Midwest. Review and edit to add details specific to your library and invoices. If additional Midwest invoice profiles are needed, duplicate this one. If no Midwest invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+86[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX+2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+LI[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "repeatableFieldAction": "EXTEND_EXISTING",
+                "value": "",
+                "subfields": [
+                  {
+                    "order": 0,
+                    "path": "invoice.invoiceLines[].referenceNumbers[]",
+                    "fields": [
+                      {
+                        "name": "refNumber",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumber",
+                        "value": "RFF+SLI[2]",
+                        "subfields": []
+                      },
+                      {
+                        "name": "refNumberType",
+                        "enabled": true,
+                        "path": "invoice.invoiceLines[].referenceNumbers[].refNumberType",
+                        "value": "\"Vendor order reference number\"",
+                        "subfields": []
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '950d9436-6a96-40f6-94c8-9ae39aef26e4';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+  "id": "8bc2ad7e-5bcf-4ee3-af34-236c0f7875ca",
+  "name": "Default - Nardi monograph invoice",
+  "incomingRecordType": "EDIFACT_INVOICE",
+  "existingRecordType": "INVOICE",
+  "deleted": false,
+  "hidden": false,
+  "description": "Default EDIFACT invoice field mapping profile for Nardi. Edit to add details specific to your library and invoices. If additional Nardi invoice profiles are needed, duplicate this one. If no Nardi invoice profile is needed, delete this one.",
+  "metadata": {
+    "createdDate": "2021-03-01T15:00:00.000",
+    "updatedDate": "2021-03-01T16:00:00.462+0000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+  },
+  "userInfo": {
+    "lastName": "System",
+    "userName": "System",
+    "firstName": "System"
+  },
+  "mappingDetails": {
+    "name": "invoice",
+    "recordType": "INVOICE",
+    "mappingFields": [
+      {
+        "name": "invoiceDate",
+        "enabled": true,
+        "path": "invoice.invoiceDate",
+        "value": "DTM+137[2]",
+        "subfields": []
+      },
+      {
+        "name": "status",
+        "enabled": true,
+        "path": "invoice.status",
+        "value": "\"Open\"",
+        "subfields": []
+      },
+      {
+        "name": "paymentDue",
+        "enabled": true,
+        "path": "invoice.paymentDue",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentTerms",
+        "enabled": true,
+        "path": "invoice.paymentTerms",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvalDate",
+        "enabled": false,
+        "path": "invoice.approvalDate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "approvedBy",
+        "enabled": false,
+        "path": "invoice.approvedBy",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "acqUnitIds",
+        "enabled": true,
+        "path": "invoice.acqUnitIds[]",
+        "value": "",
+        "subfields": [{
+          "order": 0,
+          "path": "invoice.acqUnitIds[]",
+          "fields": [{
+            "name": "acqUnitIds",
+            "enabled": true,
+            "path": "invoice.acqUnitIds[]",
+            "value": "",
+            "subfields": []
+          }]
+        }],
+        "acceptedValues": {
+          "0ebb1f7d-983f-3026-8a4c-5318e0ebc041": "main"
+        }
+      },
+      {
+        "name": "billTo",
+        "enabled": true,
+        "path": "invoice.billTo",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {}
+      },
+      {
+        "name": "billToAddress",
+        "enabled": false,
+        "path": "invoice.billToAddress",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "batchGroupId",
+        "enabled": true,
+        "path": "invoice.batchGroupId",
+        "value": "",
+        "subfields": [],
+        "acceptedValues": {
+          "2a2cb998-1437-41d1-88ad-01930aaeadd5": "FOLIO",
+          "cd592659-77aa-4eb3-ac34-c9a4657bb20f": "Amherst (AC)"
+        }
+      },
+      {
+        "name": "subTotal",
+        "enabled": false,
+        "path": "invoice.subTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustmentsTotal",
+        "enabled": false,
+        "path": "invoice.adjustmentsTotal",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "total",
+        "enabled": false,
+        "path": "invoice.total",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "lockTotal",
+        "enabled": true,
+        "path": "invoice.lockTotal",
+        "value": "MOA+9[2]",
+        "subfields": []
+      },
+      {
+        "name": "note",
+        "enabled": true,
+        "path": "invoice.note",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "adjustments",
+        "enabled": true,
+        "path": "invoice.adjustments[]",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "vendorInvoiceNo",
+        "enabled": true,
+        "path": "invoice.vendorInvoiceNo",
+        "subfields": [],
+        "value": "BGM+380+[1]"
+      },
+      {
+        "name": "vendorId",
+        "enabled": true,
+        "path": "invoice.vendorId",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "accountingCode",
+        "enabled": true,
+        "path": "invoice.accountingCode",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "folioInvoiceNo",
+        "enabled": false,
+        "path": "invoice.folioInvoiceNo",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "paymentMethod",
+        "enabled": true,
+        "path": "invoice.paymentMethod",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "chkSubscriptionOverlap",
+        "enabled": true,
+        "path": "invoice.chkSubscriptionOverlap",
+        "booleanFieldAction": "ALL_FALSE",
+        "subfields": []
+      },
+      {
+        "name": "exportToAccounting",
+        "enabled": true,
+        "path": "invoice.exportToAccounting",
+        "booleanFieldAction": "ALL_TRUE",
+        "subfields": []
+      },
+      {
+        "name": "currency",
+        "enabled": true,
+        "path": "invoice.currency",
+        "subfields": [],
+        "value": "CUX++2[2]"
+      },
+      {
+        "name": "currentExchangeRate",
+        "enabled": false,
+        "path": "invoice.currentExchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "exchangeRate",
+        "enabled": true,
+        "path": "invoice.exchangeRate",
+        "value": "",
+        "subfields": []
+      },
+      {
+        "name": "invoiceLines",
+        "enabled": true,
+        "path": "invoice.invoiceLines[]",
+        "value": "",
+        "repeatableFieldAction": "EXTEND_EXISTING",
+        "subfields": [
+          {
+            "order": 0,
+            "path": "invoice.invoiceLines[]",
+            "fields": [
+              {
+                "name": "description",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].description",
+                "value": "{POL_title}; else IMD+L+050+[4-5]",
+                "subfields": []
+              },
+              {
+                "name": "poLineId",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].poLineId",
+                "value": "RFF+ON[2]",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineNumber",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "invoiceLineStatus",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].invoiceLineStatus",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "referenceNumbers",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].referenceNumbers[]",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionInfo",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionInfo",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionStart",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionStart",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "subscriptionEnd",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subscriptionEnd",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "comment",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].comment",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "lineAccountingCode",
+                "enabled": false,
+                "path": "invoice.invoiceLines[].accountingCode",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "accountNumber",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].accountNumber",
+                "value": "",
+                "subfields": []
+              },
+              {
+                "name": "quantity",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].quantity",
+                "value": "QTY+47[2]",
+                "subfields": []
+              },
+              {
+                "name": "lineSubTotal",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].subTotal",
+                "value": "MOA+203[2]",
+                "subfields": []
+              },
+              {
+                "name": "releaseEncumbrance",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].releaseEncumbrance",
+                "booleanFieldAction": "ALL_TRUE",
+                "subfields": []
+              },
+              {
+                "name": "fundDistributions",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].fundDistributions[]",
+                "value": "{POL_FUND_DISTRIBUTIONS}",
+                "subfields": []
+              },
+              {
+                "name": "lineAdjustments",
+                "enabled": true,
+                "path": "invoice.invoiceLines[].adjustments[]",
+                "value": "",
+                "subfields": []
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}'
+WHERE id = '8bc2ad7e-5bcf-4ee3-af34-236c0f7875ca';

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_instance_and_marc_bib_create_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_instance_and_marc_bib_create_job_profile.sql
@@ -1,37 +1,13 @@
-UPDATE ${myuniversity}_${mymodule}.job_profiles
-    SET jsonb =  '{
-	"id": "6409dcff-71fa-433a-bc6a-e70ad38a9604",
-	"name": "quickMARC - Derive a new SRS MARC Bib and Instance",
-	"deleted": false,
-	"hidden": false,
-	"dataType": "MARC",
-	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
-		"createdByUserId": "00000000-0000-0000-0000-000000000000",
-		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
-	},
-	"userInfo": {
-		"lastName": "System",
-		"userName": "System",
-		"firstName": "System"
-	},
-	"description": "This job profile is used by the quickMARC Derive action to create a new SRS MARC Bib record and corresponding Inventory Instance. It cannot be edited or deleted.",
-	"childProfiles": [],
-	"parentProfiles": []
-}'
-WHERE id = '6409dcff-71fa-433a-bc6a-e70ad38a9604';
-
 UPDATE ${myuniversity}_${mymodule}.action_profiles
 SET jsonb =  '{
-	"id": "f8e58651-f651-485d-aead-d2fa8700e2d1",
-	"name": "quickMARC Derive - Create Inventory Instance",
+	"id": "fa45f3ec-9b83-11eb-a8b3-0242ac130003",
+	"name": "Default - Create instance",
 	"action": "CREATE",
 	"deleted": false,
 	"hidden": false,
 	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
+		"createdDate": "2021-04-13T14:00:00.000",
+		"updatedDate": "2021-00-13T15:00:00.462+0000",
 		"createdByUserId": "00000000-0000-0000-0000-000000000000",
 		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
 	},
@@ -40,22 +16,23 @@ SET jsonb =  '{
 		"userName": "System",
 		"firstName": "System"
 	},
-	"description": "This action profile is used by the quickMARC Derive action to create a new Inventory Instance. It cannot be edited or deleted.",
+	"description": "This action profile is used with FOLIO''s default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, or deleted.",
 	"folioRecord": "INSTANCE",
 	"childProfiles": [],
 	"parentProfiles": []
 }'
-WHERE id = 'f8e58651-f651-485d-aead-d2fa8700e2d1';
+WHERE id = 'fa45f3ec-9b83-11eb-a8b3-0242ac130003';
 
-UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+UPDATE ${myuniversity}_${mymodule}.job_profiles
 SET jsonb =  '{
-	"id": "991c0300-44a6-47e3-8ea2-b01bb56a38cc",
-	"name": "quickMARC Derive - Create Inventory Instance",
+	"id": "e34d7b92-9b83-11eb-a8b3-0242ac130003",
+	"name": "Default - Create instance and SRS MARC Bib",
 	"deleted": false,
 	"hidden": false,
+	"dataType": "MARC",
 	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
+		"createdDate": "2021-04-13T14:00:00.000",
+		"updatedDate": "2021-00-13T15:00:00.462+0000",
 		"createdByUserId": "00000000-0000-0000-0000-000000000000",
 		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
 	},
@@ -64,7 +41,30 @@ SET jsonb =  '{
 		"userName": "System",
 		"firstName": "System"
 	},
-	"description": "This field mapping profile is used by the quickMARC Derive action to create an Inventory Instance. It cannot be edited or deleted.",
+	"description": "This job profile creates SRS MARC Bib records and corresponding Inventory Instances using the library''s default MARC-to-Instance mapping. It can be edited, duplicated, or deleted.",
+	"childProfiles": [],
+	"parentProfiles": []
+}'
+WHERE id = 'e34d7b92-9b83-11eb-a8b3-0242ac130003';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+	"id": "bf7b3b86-9b84-11eb-a8b3-0242ac130003",
+	"name": "Default - Create instance",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2021-04-13T14:00:00.000",
+		"updatedDate": "2021-00-13T15:00:00.462+0000",
+		"createdByUserId": "00000000-0000-0000-0000-000000000000",
+		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "This field mapping profile is used with FOLIO''s default job profile for creating Inventory Instances and SRS MARC Bibliographic records. It can be edited, duplicated, deleted, or linked to additional action profiles.",
 	"childProfiles": [],
 	"mappingDetails": {
 		"name": "instance",
@@ -278,5 +278,4 @@ SET jsonb =  '{
 	"incomingRecordType": "MARC_BIBLIOGRAPHIC",
 	"marcFieldProtectionSettings": []
 }'
-WHERE id = '991c0300-44a6-47e3-8ea2-b01bb56a38cc';
-
+WHERE id = 'bf7b3b86-9b84-11eb-a8b3-0242ac130003';

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_authority_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_authority_job_profile.sql
@@ -4,6 +4,7 @@ SET jsonb =  '{
   "name": "Default - Create SRS MARC Authority",
   "description": "Default job profile for creating MARC authority records. These records are stored in source record storage (SRS). Profile cannot be edited or deleted",
   "deleted": false,
+  "hidden": false,
   "dataType": "MARC",
   "tags": {
     "tagList": []
@@ -30,6 +31,7 @@ SET jsonb =  '{
   "name": "Default - Create MARC Authority",
   "action": "CREATE",
   "deleted": false,
+  "hidden": false,
   "description": "This action profile is used with FOLIO''s default job profile for creating a MARC authority record in source-record-storage. It cannot be edited, duplicated, or deleted.",
   "folioRecord": "AUTHORITY",
   "childProfiles": [],
@@ -53,6 +55,7 @@ SET jsonb =  '{
   "id": "6a0ec1de-68eb-4833-bdbf-0741db25c314",
   "name": "Default - Create MARC Authority",
   "deleted": false,
+  "hidden": false,
   "metadata": {
     "createdDate": "2021-10-08T14:00:00.000",
     "updatedDate": "2021-10-08T15:00:00.462+0000",

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_holdings_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_holdings_job_profile.sql
@@ -4,6 +4,7 @@ SET jsonb =  '{
   "name": "Default - Create Holdings and SRS MARC Holdings",
   "description": "Default job profile for creating MARC holdings and corresponding Inventory holdings. Profile cannot be edited or deleted",
   "deleted": false,
+  "hidden": false,
   "dataType": "MARC",
   "tags": {
     "tagList": []
@@ -30,6 +31,7 @@ SET jsonb =  '{
   "name": "Default - Create MARC holdings",
   "action": "CREATE",
   "deleted": false,
+  "hidden": false,
   "description": "This action profile is used with FOLIO''s default job profile for creating Inventory Holdings and SRS MARC Holdings records. It cannot be edited, duplicated, or deleted.",
   "folioRecord": "HOLDINGS",
   "childProfiles": [],
@@ -53,6 +55,7 @@ SET jsonb =  '{
   "id": "13cf7adf-c7a7-4c2e-838f-14d0ac36ec0a",
   "name": "Default Create MARC holdings and Inventory holdings",
   "deleted": false,
+  "hidden": false,
   "metadata": {
     "createdDate": "2021-08-05T14:00:00.000",
     "updatedDate": "2021-08-05T15:00:00.462+0000",

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_oclc_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_oclc_job_profile.sql
@@ -1,70 +1,71 @@
 UPDATE ${myuniversity}_${mymodule}.job_profiles
-    SET jsonb =  '{
-	"id": "6409dcff-71fa-433a-bc6a-e70ad38a9604",
-	"name": "quickMARC - Derive a new SRS MARC Bib and Instance",
-	"deleted": false,
-	"hidden": false,
-	"dataType": "MARC",
-	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
-		"createdByUserId": "00000000-0000-0000-0000-000000000000",
-		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
-	},
-	"userInfo": {
-		"lastName": "System",
-		"userName": "System",
-		"firstName": "System"
-	},
-	"description": "This job profile is used by the quickMARC Derive action to create a new SRS MARC Bib record and corresponding Inventory Instance. It cannot be edited or deleted.",
-	"childProfiles": [],
-	"parentProfiles": []
+SET jsonb =  '{
+  "id": "d0ebb7b0-2f0f-11eb-adc1-0242ac120002",
+  "name": "Inventory Single Record - Default Create Instance",
+  "description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to create an Instance and MARC record",
+  "dataType": "MARC",
+  "tags": {
+    "tagList": []
+  },
+  "deleted": false,
+  "hidden": false,
+  "userInfo": {
+    "firstName": "System",
+    "lastName": "System",
+    "userName": "System"
+  },
+  "childProfiles": [],
+  "parentProfiles": [],
+  "metadata": {
+    "createdDate": "2020-11-23T12:00:00.000",
+    "createdByUserId": "00000000-0000-0000-0000-000000000000",
+    "createdByUsername": "System",
+    "updatedDate": "2020-11-24T12:00:00.000",
+    "updatedByUserId": "00000000-0000-0000-0000-000000000000",
+    "updatedByUsername": "System"
+  }
 }'
-WHERE id = '6409dcff-71fa-433a-bc6a-e70ad38a9604';
+WHERE id = 'd0ebb7b0-2f0f-11eb-adc1-0242ac120002';
 
 UPDATE ${myuniversity}_${mymodule}.action_profiles
 SET jsonb =  '{
-	"id": "f8e58651-f651-485d-aead-d2fa8700e2d1",
-	"name": "quickMARC Derive - Create Inventory Instance",
+	"id": "d0ebba8a-2f0f-11eb-adc1-0242ac120002",
+	"name": "Inventory Single Record - Default Create Instance",
 	"action": "CREATE",
 	"deleted": false,
 	"hidden": false,
-	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
-		"createdByUserId": "00000000-0000-0000-0000-000000000000",
-		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
-	},
 	"userInfo": {
 		"lastName": "System",
 		"userName": "System",
 		"firstName": "System"
 	},
-	"description": "This action profile is used by the quickMARC Derive action to create a new Inventory Instance. It cannot be edited or deleted.",
+	"description": "Creates new Inventory Instances and SRS MARC Bib records based on Inventory single record imports",
 	"folioRecord": "INSTANCE",
 	"childProfiles": [],
-	"parentProfiles": []
+	"parentProfiles": [],
+	"metadata": {
+        "createdDate": "2020-11-23T12:00:00.000",
+        "createdByUserId": "00000000-0000-0000-0000-000000000000",
+        "createdByUsername": "System",
+        "updatedDate": "2020-11-24T12:00:00.000",
+        "updatedByUserId": "00000000-0000-0000-0000-000000000000",
+        "updatedByUsername": "System"
+	}
 }'
-WHERE id = 'f8e58651-f651-485d-aead-d2fa8700e2d1';
+WHERE id = 'd0ebba8a-2f0f-11eb-adc1-0242ac120002';
 
 UPDATE ${myuniversity}_${mymodule}.mapping_profiles
 SET jsonb =  '{
-	"id": "991c0300-44a6-47e3-8ea2-b01bb56a38cc",
-	"name": "quickMARC Derive - Create Inventory Instance",
+	"id": "d0ebbc2e-2f0f-11eb-adc1-0242ac120002",
+	"name": "Inventory Single Record - Default Create Instance",
 	"deleted": false,
 	"hidden": false,
-	"metadata": {
-		"createdDate": "2021-01-14T14:00:00.000",
-		"updatedDate": "2021-01-14T15:00:00.462+0000",
-		"createdByUserId": "00000000-0000-0000-0000-000000000000",
-		"updatedByUserId": "00000000-0000-0000-0000-000000000000"
-	},
 	"userInfo": {
 		"lastName": "System",
 		"userName": "System",
 		"firstName": "System"
 	},
-	"description": "This field mapping profile is used by the quickMARC Derive action to create an Inventory Instance. It cannot be edited or deleted.",
+	"description": "Creates new Inventory Instances and SRS MARC Bib records based on Inventory single record imports",
 	"childProfiles": [],
 	"mappingDetails": {
 		"name": "instance",
@@ -276,7 +277,14 @@ SET jsonb =  '{
 	"parentProfiles": [],
 	"existingRecordType": "INSTANCE",
 	"incomingRecordType": "MARC_BIBLIOGRAPHIC",
-	"marcFieldProtectionSettings": []
+	"marcFieldProtectionSettings": [],
+	"metadata": {
+		"createdDate": "2020-11-23T12:00:00.000",
+		"createdByUserId": "00000000-0000-0000-0000-000000000000",
+		"createdByUsername": "System",
+		"updatedDate": "2020-11-24T12:00:00.000",
+		"updatedByUserId": "00000000-0000-0000-0000-000000000000",
+		"updatedByUsername": "System"
+  }
 }'
-WHERE id = '991c0300-44a6-47e3-8ea2-b01bb56a38cc';
-
+WHERE id = 'd0ebbc2e-2f0f-11eb-adc1-0242ac120002';

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_oclc_update_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_oclc_update_job_profile.sql
@@ -1,0 +1,3408 @@
+UPDATE ${myuniversity}_${mymodule}.job_profiles
+SET jsonb =  '{
+	"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+	"name": "Inventory Single Record - Default Update Instance",
+	"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+	"deleted": false,
+	"hidden": false,
+	"dataType": "MARC",
+	"metadata": {
+		"createdDate": "2020-11-30T09:07:47.667",
+		"updatedDate": "2020-11-30T09:09:10.382+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"childProfiles": [],
+	"parentProfiles": []
+}'
+WHERE id = '91f9b8d6-d80e-4727-9783-73fb53e3c786';
+
+UPDATE ${myuniversity}_${mymodule}.action_profiles
+SET jsonb =  '{
+	"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+	"name": "Inventory Single Record - Default Update Instance",
+	"action": "UPDATE",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:03:05.334",
+		"updatedDate": "2020-11-30T11:57:14.464+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Updates existing Inventory Instances based on Inventory single record imports",
+	"folioRecord": "INSTANCE",
+	"childProfiles": [{
+			"id": "862000b9-84ea-4cae-a223-5fc0552f2b42",
+			"order": 0,
+			"content": {
+				"id": "862000b9-84ea-4cae-a223-5fc0552f2b42",
+				"name": "Update instance",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726889039,
+					"updatedDate": 1606726889039,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "",
+				"childProfiles": [],
+				"mappingDetails": {
+					"name": "instance",
+					"recordType": "INSTANCE",
+					"mappingFields": [{
+							"name": "discoverySuppress",
+							"path": "instance.discoverySuppress",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "staffSuppress",
+							"path": "instance.staffSuppress",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "previouslyHeld",
+							"path": "instance.previouslyHeld",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "hrid",
+							"path": "instance.hrid",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "source",
+							"path": "instance.source",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "catalogedDate",
+							"path": "instance.catalogedDate",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "statusId",
+							"path": "instance.statusId",
+							"value": "",
+							"enabled": "true",
+							"subfields": [],
+							"acceptedValues": {
+								"26f5208e-110a-4394-be29-1569a8c84a65": "Uncataloged",
+								"2a340d34-6b70-443a-bb1b-1b8d1c65d862": "Other",
+								"52a2ff34-2a12-420d-8539-21aa8d3cf5d8": "Batch Loaded",
+								"9634a5ab-9228-4703-baf2-4d12ebc77d56": "Cataloged",
+								"daf2681c-25af-4202-a3fa-e58fdf806183": "Temporary",
+								"f5cc2ab6-bb92-4cab-b83f-5a3d09261a41": "Not yet assigned"
+							}
+						}, {
+							"name": "modeOfIssuanceId",
+							"path": "instance.modeOfIssuanceId",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "statisticalCodeIds",
+							"path": "instance.statisticalCodeIds[]",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "title",
+							"path": "instance.title",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "alternativeTitles",
+							"path": "instance.alternativeTitles[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "indexTitle",
+							"path": "instance.indexTitle",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "series",
+							"path": "instance.series[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "precedingTitles",
+							"path": "instance.precedingTitles[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "succeedingTitles",
+							"path": "instance.succeedingTitles[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "identifiers",
+							"path": "instance.identifiers[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "contributors",
+							"path": "instance.contributors[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "publication",
+							"path": "instance.publication[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "editions",
+							"path": "instance.editions[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "physicalDescriptions",
+							"path": "instance.physicalDescriptions[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "instanceTypeId",
+							"path": "instance.instanceTypeId",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "natureOfContentTermIds",
+							"path": "instance.natureOfContentTermIds[]",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "instanceFormatIds",
+							"path": "instance.instanceFormatIds[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "languages",
+							"path": "instance.languages[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "publicationFrequency",
+							"path": "instance.publicationFrequency[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "publicationRange",
+							"path": "instance.publicationRange[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "notes",
+							"path": "instance.notes[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "electronicAccess",
+							"path": "instance.electronicAccess[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "subjects",
+							"path": "instance.subjects[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "classifications",
+							"path": "instance.classifications[]",
+							"value": "",
+							"enabled": "false",
+							"subfields": []
+						}, {
+							"name": "parentInstances",
+							"path": "instance.parentInstances[]",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}, {
+							"name": "childInstances",
+							"path": "instance.childInstances[]",
+							"value": "",
+							"enabled": "true",
+							"subfields": []
+						}
+					],
+					"marcMappingDetails": []
+				},
+				"parentProfiles": [],
+				"existingRecordType": "INSTANCE",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+				"marcFieldProtectionSettings": []
+			},
+			"contentType": "MAPPING_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"parentProfiles": [{
+			"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+			"order": 0,
+			"content": {
+				"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+				"name": "Inventory Single Record - Default match for no SRS record",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606727217367,
+					"updatedDate": 1606730410359,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the UUID of the existing Instance record",
+				"matchDetails": [{
+						"matchCriterion": "EXACTLY_MATCHES",
+						"existingRecordType": "INSTANCE",
+						"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+						"existingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "instance.id"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						},
+						"incomingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						}
+					}
+				],
+				"childProfiles": [{
+						"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+						"order": 0,
+						"content": {
+							"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+							"name": "Update instance",
+							"action": "UPDATE",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726985334,
+								"updatedDate": 1606726985334,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"folioRecord": "INSTANCE",
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "ACTION_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+						"order": 0,
+						"content": {
+							"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+							"name": "Inventory Single Record - Default match for existing SRS record",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727161520,
+								"updatedDate": 1606730341248,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "MARC_BIBLIOGRAPHIC",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+									"order": 0,
+									"content": {
+										"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+										"name": "March Profile by Instance UUID",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727217367,
+											"updatedDate": 1606729869001,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "INSTANCE",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "instance.id"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [{
+												"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+												"order": 0,
+												"content": {
+													"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+													"name": "Update instance",
+													"action": "UPDATE",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606726985334,
+														"updatedDate": 1606726985334,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"folioRecord": "INSTANCE",
+													"childProfiles": [],
+													"parentProfiles": []
+												},
+												"contentType": "ACTION_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"parentProfiles": [{
+												"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+												"order": 0,
+												"content": {
+													"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+													"name": "MARC-2-MARC",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606727161520,
+														"updatedDate": 1606727161520,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"matchDetails": [{
+															"matchCriterion": "EXACTLY_MATCHES",
+															"existingRecordType": "MARC_BIBLIOGRAPHIC",
+															"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+															"existingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															},
+															"incomingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															}
+														}
+													],
+													"childProfiles": [],
+													"parentProfiles": [],
+													"existingRecordType": "MARC_BIBLIOGRAPHIC",
+													"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+												},
+												"contentType": "MATCH_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"existingRecordType": "INSTANCE",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}, {
+									"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+									"order": 0,
+									"content": {
+										"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+										"name": "Update MARC Bib",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726959960,
+											"updatedDate": 1606726959960,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "MARC_BIBLIOGRAPHIC",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+									"order": 0,
+									"content": {
+										"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+										"name": "Inventory Single Record - Default Update Instance",
+										"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+										"deleted": false,
+										"hidden": false,
+										"dataType": "MARC",
+										"metadata": {
+											"createdDate": 1606727267667,
+											"updatedDate": 1606727350382,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "JOB_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "MARC_BIBLIOGRAPHIC",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"existingRecordType": "INSTANCE",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+			},
+			"contentType": "MATCH_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	]
+}'
+WHERE id = 'cddff0e1-233c-47ba-8be5-553c632709d9';
+
+UPDATE ${myuniversity}_${mymodule}.action_profiles
+SET jsonb =  '{
+	"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+	"name": "Inventory Single Record - Default Update MARC Bib",
+	"action": "UPDATE",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:02:39.96",
+		"updatedDate": "2020-11-30T11:57:24.083+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Updates existing SRS MARC Bib records based on Inventory single record imports",
+	"folioRecord": "MARC_BIBLIOGRAPHIC",
+	"childProfiles": [{
+			"id": "f90864ef-8030-480f-a43f-8cdd21233252",
+			"order": 0,
+			"content": {
+				"id": "f90864ef-8030-480f-a43f-8cdd21233252",
+				"name": "Update MARC Bib",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726926555,
+					"updatedDate": 1606726926555,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "",
+				"childProfiles": [],
+				"mappingDetails": {
+					"name": "marcBib",
+					"recordType": "MARC_BIBLIOGRAPHIC",
+					"mappingFields": [],
+					"marcMappingOption": "UPDATE",
+					"marcMappingDetails": []
+				},
+				"parentProfiles": [],
+				"existingRecordType": "MARC_BIBLIOGRAPHIC",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+				"marcFieldProtectionSettings": []
+			},
+			"contentType": "MAPPING_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"parentProfiles": [{
+			"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+			"order": 0,
+			"content": {
+				"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+				"name": "Inventory Single Record - Default match for existing SRS record",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606727161520,
+					"updatedDate": 1606730341248,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+				"matchDetails": [{
+						"matchCriterion": "EXACTLY_MATCHES",
+						"existingRecordType": "MARC_BIBLIOGRAPHIC",
+						"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+						"existingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						},
+						"incomingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						}
+					}
+				],
+				"childProfiles": [{
+						"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+						"order": 0,
+						"content": {
+							"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+							"name": "March Profile by Instance UUID",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727217367,
+								"updatedDate": 1606729869001,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "INSTANCE",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "instance.id"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+									"order": 0,
+									"content": {
+										"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+										"name": "Update instance",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726985334,
+											"updatedDate": 1606726985334,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "INSTANCE",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+									"order": 0,
+									"content": {
+										"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+										"name": "MARC-2-MARC",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727161520,
+											"updatedDate": 1606727161520,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "MARC_BIBLIOGRAPHIC",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [],
+										"parentProfiles": [],
+										"existingRecordType": "MARC_BIBLIOGRAPHIC",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "INSTANCE",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}, {
+						"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+						"order": 0,
+						"content": {
+							"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+							"name": "Update MARC Bib",
+							"action": "UPDATE",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726959960,
+								"updatedDate": 1606726959960,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"folioRecord": "MARC_BIBLIOGRAPHIC",
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "ACTION_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+						"order": 0,
+						"content": {
+							"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+							"name": "Inventory Single Record - Default Update Instance",
+							"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+							"deleted": false,
+							"hidden": false,
+							"dataType": "MARC",
+							"metadata": {
+								"createdDate": 1606727267667,
+								"updatedDate": 1606727350382,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "JOB_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"existingRecordType": "MARC_BIBLIOGRAPHIC",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+			},
+			"contentType": "MATCH_PROFILE",
+			"childSnapshotWrappers": []
+		}, {
+			"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+			"order": 0,
+			"content": {
+				"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+				"name": "Inventory Single Record - Default match for existing SRS record",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606727161520,
+					"updatedDate": 1606730341248,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+				"matchDetails": [{
+						"matchCriterion": "EXACTLY_MATCHES",
+						"existingRecordType": "MARC_BIBLIOGRAPHIC",
+						"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+						"existingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						},
+						"incomingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						}
+					}
+				],
+				"childProfiles": [{
+						"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+						"order": 0,
+						"content": {
+							"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+							"name": "March Profile by Instance UUID",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727217367,
+								"updatedDate": 1606729869001,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "INSTANCE",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "instance.id"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+									"order": 0,
+									"content": {
+										"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+										"name": "Update instance",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726985334,
+											"updatedDate": 1606726985334,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "INSTANCE",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+									"order": 0,
+									"content": {
+										"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+										"name": "MARC-2-MARC",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727161520,
+											"updatedDate": 1606727161520,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "MARC_BIBLIOGRAPHIC",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [],
+										"parentProfiles": [],
+										"existingRecordType": "MARC_BIBLIOGRAPHIC",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "INSTANCE",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}, {
+						"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+						"order": 0,
+						"content": {
+							"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+							"name": "Update MARC Bib",
+							"action": "UPDATE",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726959960,
+								"updatedDate": 1606726959960,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"folioRecord": "MARC_BIBLIOGRAPHIC",
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "ACTION_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+						"order": 0,
+						"content": {
+							"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+							"name": "Inventory Single Record - Default Update Instance",
+							"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+							"deleted": false,
+							"hidden": false,
+							"dataType": "MARC",
+							"metadata": {
+								"createdDate": 1606727267667,
+								"updatedDate": 1606727350382,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "JOB_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"existingRecordType": "MARC_BIBLIOGRAPHIC",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+			},
+			"contentType": "MATCH_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	]
+}'
+WHERE id = '6aa8e98b-0d9f-41dd-b26f-15658d07eb52';
+
+UPDATE ${myuniversity}_${mymodule}.match_profiles
+SET jsonb =  '{
+	"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+	"name": "Inventory Single Record - Default match for existing SRS record",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:06:01.52",
+		"updatedDate": "2020-11-30T09:59:01.248+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+	"matchDetails": [{
+			"matchCriterion": "EXACTLY_MATCHES",
+			"existingRecordType": "MARC_BIBLIOGRAPHIC",
+			"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+			"existingMatchExpression": {
+				"fields": [{
+						"label": "field",
+						"value": "999"
+					}, {
+						"label": "indicator1",
+						"value": "f"
+					}, {
+						"label": "indicator2",
+						"value": "f"
+					}, {
+						"label": "recordSubfield",
+						"value": "i"
+					}
+				],
+				"dataValueType": "VALUE_FROM_RECORD"
+			},
+			"incomingMatchExpression": {
+				"fields": [{
+						"label": "field",
+						"value": "999"
+					}, {
+						"label": "indicator1",
+						"value": "f"
+					}, {
+						"label": "indicator2",
+						"value": "f"
+					}, {
+						"label": "recordSubfield",
+						"value": "i"
+					}
+				],
+				"dataValueType": "VALUE_FROM_RECORD"
+			}
+		}
+	],
+	"childProfiles": [{
+			"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+			"order": 0,
+			"content": {
+				"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+				"name": "March Profile by Instance UUID",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606727217367,
+					"updatedDate": 1606729869001,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "",
+				"matchDetails": [{
+						"matchCriterion": "EXACTLY_MATCHES",
+						"existingRecordType": "INSTANCE",
+						"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+						"existingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "instance.id"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						},
+						"incomingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						}
+					}
+				],
+				"childProfiles": [{
+						"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+						"order": 0,
+						"content": {
+							"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+							"name": "Update instance",
+							"action": "UPDATE",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726985334,
+								"updatedDate": 1606726985334,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"folioRecord": "INSTANCE",
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "ACTION_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+						"order": 0,
+						"content": {
+							"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+							"name": "MARC-2-MARC",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727161520,
+								"updatedDate": 1606727161520,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "MARC_BIBLIOGRAPHIC",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [],
+							"parentProfiles": [],
+							"existingRecordType": "MARC_BIBLIOGRAPHIC",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"existingRecordType": "INSTANCE",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+			},
+			"contentType": "MATCH_PROFILE",
+			"childSnapshotWrappers": []
+		}, {
+			"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+			"order": 0,
+			"content": {
+				"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+				"name": "Update MARC Bib",
+				"action": "UPDATE",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726959960,
+					"updatedDate": 1606726959960,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "",
+				"folioRecord": "MARC_BIBLIOGRAPHIC",
+				"childProfiles": [],
+				"parentProfiles": []
+			},
+			"contentType": "ACTION_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"parentProfiles": [{
+			"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+			"order": 0,
+			"content": {
+				"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+				"name": "Inventory Single Record - Default Update Instance",
+				"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+				"deleted": false,
+				"hidden": false,
+				"dataType": "MARC",
+				"metadata": {
+					"createdDate": 1606727267667,
+					"updatedDate": 1606727350382,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"childProfiles": [],
+				"parentProfiles": []
+			},
+			"contentType": "JOB_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"existingRecordType": "MARC_BIBLIOGRAPHIC",
+	"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+}'
+WHERE id = 'd27d71ce-8a1e-44c6-acea-96961b5592c6';
+
+UPDATE ${myuniversity}_${mymodule}.match_profiles
+SET jsonb =  '{
+	"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+	"name": "Inventory Single Record - Default match for no SRS record",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:06:57.367",
+		"updatedDate": "2020-11-30T10:00:10.359+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the UUID of the existing Instance record",
+	"matchDetails": [{
+			"matchCriterion": "EXACTLY_MATCHES",
+			"existingRecordType": "INSTANCE",
+			"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+			"existingMatchExpression": {
+				"fields": [{
+						"label": "field",
+						"value": "instance.id"
+					}
+				],
+				"dataValueType": "VALUE_FROM_RECORD"
+			},
+			"incomingMatchExpression": {
+				"fields": [{
+						"label": "field",
+						"value": "999"
+					}, {
+						"label": "indicator1",
+						"value": "f"
+					}, {
+						"label": "indicator2",
+						"value": "f"
+					}, {
+						"label": "recordSubfield",
+						"value": "i"
+					}
+				],
+				"dataValueType": "VALUE_FROM_RECORD"
+			}
+		}
+	],
+	"childProfiles": [{
+			"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+			"order": 0,
+			"content": {
+				"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+				"name": "Update instance",
+				"action": "UPDATE",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726985334,
+					"updatedDate": 1606726985334,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "",
+				"folioRecord": "INSTANCE",
+				"childProfiles": [],
+				"parentProfiles": []
+			},
+			"contentType": "ACTION_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"parentProfiles": [{
+			"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+			"order": 0,
+			"content": {
+				"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+				"name": "Inventory Single Record - Default match for existing SRS record",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606727161520,
+					"updatedDate": 1606730341248,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+				"matchDetails": [{
+						"matchCriterion": "EXACTLY_MATCHES",
+						"existingRecordType": "MARC_BIBLIOGRAPHIC",
+						"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+						"existingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						},
+						"incomingMatchExpression": {
+							"fields": [{
+									"label": "field",
+									"value": "999"
+								}, {
+									"label": "indicator1",
+									"value": "f"
+								}, {
+									"label": "indicator2",
+									"value": "f"
+								}, {
+									"label": "recordSubfield",
+									"value": "i"
+								}
+							],
+							"dataValueType": "VALUE_FROM_RECORD"
+						}
+					}
+				],
+				"childProfiles": [{
+						"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+						"order": 0,
+						"content": {
+							"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+							"name": "March Profile by Instance UUID",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727217367,
+								"updatedDate": 1606729869001,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "INSTANCE",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "instance.id"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+									"order": 0,
+									"content": {
+										"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+										"name": "Update instance",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726985334,
+											"updatedDate": 1606726985334,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "INSTANCE",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+									"order": 0,
+									"content": {
+										"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+										"name": "MARC-2-MARC",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727161520,
+											"updatedDate": 1606727161520,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "MARC_BIBLIOGRAPHIC",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [],
+										"parentProfiles": [],
+										"existingRecordType": "MARC_BIBLIOGRAPHIC",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "INSTANCE",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}, {
+						"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+						"order": 0,
+						"content": {
+							"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+							"name": "Update MARC Bib",
+							"action": "UPDATE",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726959960,
+								"updatedDate": 1606726959960,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"folioRecord": "MARC_BIBLIOGRAPHIC",
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "ACTION_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+						"order": 0,
+						"content": {
+							"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+							"name": "Inventory Single Record - Default Update Instance",
+							"description": ",Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+							"deleted": false,
+							"hidden": false,
+							"dataType": "MARC",
+							"metadata": {
+								"createdDate": 1606727267667,
+								"updatedDate": 1606727350382,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"childProfiles": [],
+							"parentProfiles": []
+						},
+						"contentType": "JOB_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"existingRecordType": "MARC_BIBLIOGRAPHIC",
+				"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+			},
+			"contentType": "MATCH_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"existingRecordType": "INSTANCE",
+	"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+}'
+WHERE id = '31dbb554-0826-48ec-a0a4-3c55293d4dee';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+	"id": "862000b9-84ea-4cae-a223-5fc0552f2b42",
+	"name": "Inventory Single Record - Default Update Instance",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:01:29.039",
+		"updatedDate": "2020-11-30T11:57:35.927+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Updates existing Inventory Instances based on Inventory single record imports",
+	"childProfiles": [],
+	"mappingDetails": {
+		"name": "instance",
+		"recordType": "INSTANCE",
+		"mappingFields": [{
+				"name": "discoverySuppress",
+				"path": "instance.discoverySuppress",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "staffSuppress",
+				"path": "instance.staffSuppress",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "previouslyHeld",
+				"path": "instance.previouslyHeld",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "hrid",
+				"path": "instance.hrid",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "source",
+				"path": "instance.source",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "catalogedDate",
+				"path": "instance.catalogedDate",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "statusId",
+				"path": "instance.statusId",
+				"value": "",
+				"enabled": "true",
+				"subfields": [],
+				"acceptedValues": {
+					"26f5208e-110a-4394-be29-1569a8c84a65": "Uncataloged",
+					"2a340d34-6b70-443a-bb1b-1b8d1c65d862": "Other",
+					"52a2ff34-2a12-420d-8539-21aa8d3cf5d8": "Batch Loaded",
+					"9634a5ab-9228-4703-baf2-4d12ebc77d56": "Cataloged",
+					"daf2681c-25af-4202-a3fa-e58fdf806183": "Temporary",
+					"f5cc2ab6-bb92-4cab-b83f-5a3d09261a41": "Not yet assigned"
+				}
+			}, {
+				"name": "modeOfIssuanceId",
+				"path": "instance.modeOfIssuanceId",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "statisticalCodeIds",
+				"path": "instance.statisticalCodeIds[]",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "title",
+				"path": "instance.title",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "alternativeTitles",
+				"path": "instance.alternativeTitles[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "indexTitle",
+				"path": "instance.indexTitle",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "series",
+				"path": "instance.series[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "precedingTitles",
+				"path": "instance.precedingTitles[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "succeedingTitles",
+				"path": "instance.succeedingTitles[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "identifiers",
+				"path": "instance.identifiers[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "contributors",
+				"path": "instance.contributors[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "publication",
+				"path": "instance.publication[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "editions",
+				"path": "instance.editions[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "physicalDescriptions",
+				"path": "instance.physicalDescriptions[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "instanceTypeId",
+				"path": "instance.instanceTypeId",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "natureOfContentTermIds",
+				"path": "instance.natureOfContentTermIds[]",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "instanceFormatIds",
+				"path": "instance.instanceFormatIds[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "languages",
+				"path": "instance.languages[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "publicationFrequency",
+				"path": "instance.publicationFrequency[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "publicationRange",
+				"path": "instance.publicationRange[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "notes",
+				"path": "instance.notes[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "electronicAccess",
+				"path": "instance.electronicAccess[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "subjects",
+				"path": "instance.subjects[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "classifications",
+				"path": "instance.classifications[]",
+				"value": "",
+				"enabled": "false",
+				"subfields": []
+			}, {
+				"name": "parentInstances",
+				"path": "instance.parentInstances[]",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}, {
+				"name": "childInstances",
+				"path": "instance.childInstances[]",
+				"value": "",
+				"enabled": "true",
+				"subfields": []
+			}
+		],
+		"marcMappingDetails": []
+	},
+	"parentProfiles": [{
+			"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+			"order": 0,
+			"content": {
+				"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+				"name": "Inventory Single Record - Default Update Instance",
+				"action": "UPDATE",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726985334,
+					"updatedDate": 1606737434464,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Updates existing Inventory Instances based on Inventory single record imports",
+				"folioRecord": "INSTANCE",
+				"childProfiles": [{
+						"id": "862000b9-84ea-4cae-a223-5fc0552f2b42",
+						"order": 0,
+						"content": {
+							"id": "862000b9-84ea-4cae-a223-5fc0552f2b42",
+							"name": "Update instance",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726889039,
+								"updatedDate": 1606726889039,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"childProfiles": [],
+							"mappingDetails": {
+								"name": "instance",
+								"recordType": "INSTANCE",
+								"mappingFields": [{
+										"name": "discoverySuppress",
+										"path": "instance.discoverySuppress",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "staffSuppress",
+										"path": "instance.staffSuppress",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "previouslyHeld",
+										"path": "instance.previouslyHeld",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "hrid",
+										"path": "instance.hrid",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "source",
+										"path": "instance.source",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "catalogedDate",
+										"path": "instance.catalogedDate",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "statusId",
+										"path": "instance.statusId",
+										"value": "",
+										"enabled": "true",
+										"subfields": [],
+										"acceptedValues": {
+											"26f5208e-110a-4394-be29-1569a8c84a65": "Uncataloged",
+											"2a340d34-6b70-443a-bb1b-1b8d1c65d862": "Other",
+											"52a2ff34-2a12-420d-8539-21aa8d3cf5d8": "Batch Loaded",
+											"9634a5ab-9228-4703-baf2-4d12ebc77d56": "Cataloged",
+											"daf2681c-25af-4202-a3fa-e58fdf806183": "Temporary",
+											"f5cc2ab6-bb92-4cab-b83f-5a3d09261a41": "Not yet assigned"
+										}
+									}, {
+										"name": "modeOfIssuanceId",
+										"path": "instance.modeOfIssuanceId",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "statisticalCodeIds",
+										"path": "instance.statisticalCodeIds[]",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "title",
+										"path": "instance.title",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "alternativeTitles",
+										"path": "instance.alternativeTitles[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "indexTitle",
+										"path": "instance.indexTitle",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "series",
+										"path": "instance.series[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "precedingTitles",
+										"path": "instance.precedingTitles[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "succeedingTitles",
+										"path": "instance.succeedingTitles[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "identifiers",
+										"path": "instance.identifiers[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "contributors",
+										"path": "instance.contributors[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "publication",
+										"path": "instance.publication[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "editions",
+										"path": "instance.editions[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "physicalDescriptions",
+										"path": "instance.physicalDescriptions[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "instanceTypeId",
+										"path": "instance.instanceTypeId",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "natureOfContentTermIds",
+										"path": "instance.natureOfContentTermIds[]",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "instanceFormatIds",
+										"path": "instance.instanceFormatIds[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "languages",
+										"path": "instance.languages[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "publicationFrequency",
+										"path": "instance.publicationFrequency[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "publicationRange",
+										"path": "instance.publicationRange[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "notes",
+										"path": "instance.notes[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "electronicAccess",
+										"path": "instance.electronicAccess[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "subjects",
+										"path": "instance.subjects[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "classifications",
+										"path": "instance.classifications[]",
+										"value": "",
+										"enabled": "false",
+										"subfields": []
+									}, {
+										"name": "parentInstances",
+										"path": "instance.parentInstances[]",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}, {
+										"name": "childInstances",
+										"path": "instance.childInstances[]",
+										"value": "",
+										"enabled": "true",
+										"subfields": []
+									}
+								],
+								"marcMappingDetails": []
+							},
+							"parentProfiles": [],
+							"existingRecordType": "INSTANCE",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+							"marcFieldProtectionSettings": []
+						},
+						"contentType": "MAPPING_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+						"order": 0,
+						"content": {
+							"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+							"name": "Inventory Single Record - Default match for no SRS record",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727217367,
+								"updatedDate": 1606730410359,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the UUID of the existing Instance record",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "INSTANCE",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "instance.id"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+									"order": 0,
+									"content": {
+										"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+										"name": "Update instance",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726985334,
+											"updatedDate": 1606726985334,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "INSTANCE",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+									"order": 0,
+									"content": {
+										"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+										"name": "Inventory Single Record - Default match for existing SRS record",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727161520,
+											"updatedDate": 1606730341248,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "MARC_BIBLIOGRAPHIC",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [{
+												"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+												"order": 0,
+												"content": {
+													"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+													"name": "March Profile by Instance UUID",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606727217367,
+														"updatedDate": 1606729869001,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"matchDetails": [{
+															"matchCriterion": "EXACTLY_MATCHES",
+															"existingRecordType": "INSTANCE",
+															"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+															"existingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "instance.id"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															},
+															"incomingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															}
+														}
+													],
+													"childProfiles": [{
+															"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+															"order": 0,
+															"content": {
+																"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+																"name": "Update instance",
+																"action": "UPDATE",
+																"deleted": false,
+																"hidden": false,
+																"metadata": {
+																	"createdDate": 1606726985334,
+																	"updatedDate": 1606726985334,
+																	"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+																	"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+																},
+																"userInfo": {
+																	"lastName": "System",
+																	"userName": "System",
+																	"firstName": "System"
+																},
+																"description": "",
+																"folioRecord": "INSTANCE",
+																"childProfiles": [],
+																"parentProfiles": []
+															},
+															"contentType": "ACTION_PROFILE",
+															"childSnapshotWrappers": []
+														}
+													],
+													"parentProfiles": [{
+															"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+															"order": 0,
+															"content": {
+																"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+																"name": "MARC-2-MARC",
+																"deleted": false,
+																"hidden": false,
+																"metadata": {
+																	"createdDate": 1606727161520,
+																	"updatedDate": 1606727161520,
+																	"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+																	"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+																},
+																"userInfo": {
+																	"lastName": "System",
+																	"userName": "System",
+																	"firstName": "System"
+																},
+																"description": "",
+																"matchDetails": [{
+																		"matchCriterion": "EXACTLY_MATCHES",
+																		"existingRecordType": "MARC_BIBLIOGRAPHIC",
+																		"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+																		"existingMatchExpression": {
+																			"fields": [{
+																					"label": "field",
+																					"value": "999"
+																				}, {
+																					"label": "indicator1",
+																					"value": "f"
+																				}, {
+																					"label": "indicator2",
+																					"value": "f"
+																				}, {
+																					"label": "recordSubfield",
+																					"value": "i"
+																				}
+																			],
+																			"dataValueType": "VALUE_FROM_RECORD"
+																		},
+																		"incomingMatchExpression": {
+																			"fields": [{
+																					"label": "field",
+																					"value": "999"
+																				}, {
+																					"label": "indicator1",
+																					"value": "f"
+																				}, {
+																					"label": "indicator2",
+																					"value": "f"
+																				}, {
+																					"label": "recordSubfield",
+																					"value": "i"
+																				}
+																			],
+																			"dataValueType": "VALUE_FROM_RECORD"
+																		}
+																	}
+																],
+																"childProfiles": [],
+																"parentProfiles": [],
+																"existingRecordType": "MARC_BIBLIOGRAPHIC",
+																"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+															},
+															"contentType": "MATCH_PROFILE",
+															"childSnapshotWrappers": []
+														}
+													],
+													"existingRecordType": "INSTANCE",
+													"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+												},
+												"contentType": "MATCH_PROFILE",
+												"childSnapshotWrappers": []
+											}, {
+												"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+												"order": 0,
+												"content": {
+													"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+													"name": "Update MARC Bib",
+													"action": "UPDATE",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606726959960,
+														"updatedDate": 1606726959960,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"folioRecord": "MARC_BIBLIOGRAPHIC",
+													"childProfiles": [],
+													"parentProfiles": []
+												},
+												"contentType": "ACTION_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"parentProfiles": [{
+												"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+												"order": 0,
+												"content": {
+													"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+													"name": "Inventory Single Record - Default Update Instance",
+													"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+													"deleted": false,
+													"hidden": false,
+													"dataType": "MARC",
+													"metadata": {
+														"createdDate": 1606727267667,
+														"updatedDate": 1606727350382,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"childProfiles": [],
+													"parentProfiles": []
+												},
+												"contentType": "JOB_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"existingRecordType": "MARC_BIBLIOGRAPHIC",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "INSTANCE",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				]
+			},
+			"contentType": "ACTION_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"existingRecordType": "INSTANCE",
+	"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+	"marcFieldProtectionSettings": []
+}'
+WHERE id = '862000b9-84ea-4cae-a223-5fc0552f2b42';
+
+UPDATE ${myuniversity}_${mymodule}.mapping_profiles
+SET jsonb =  '{
+	"id": "f90864ef-8030-480f-a43f-8cdd21233252",
+	"name": "Inventory Single Record - Default Update MARC Bib",
+	"deleted": false,
+	"hidden": false,
+	"metadata": {
+		"createdDate": "2020-11-30T09:02:06.555",
+		"updatedDate": "2020-11-30T11:57:46.948+0000",
+		"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+		"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+	},
+	"userInfo": {
+		"lastName": "System",
+		"userName": "System",
+		"firstName": "System"
+	},
+	"description": "Updates existing SRS MARC Bib records based on Inventory single record imports",
+	"childProfiles": [],
+	"mappingDetails": {
+		"name": "marcBib",
+		"recordType": "MARC_BIBLIOGRAPHIC",
+		"mappingFields": [],
+		"marcMappingOption": "UPDATE",
+		"marcMappingDetails": []
+	},
+	"parentProfiles": [{
+			"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+			"order": 0,
+			"content": {
+				"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+				"name": "Inventory Single Record - Default Update MARC Bib",
+				"action": "UPDATE",
+				"deleted": false,
+				"hidden": false,
+				"metadata": {
+					"createdDate": 1606726959960,
+					"updatedDate": 1606737444083,
+					"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+					"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+				},
+				"userInfo": {
+					"lastName": "System",
+					"userName": "System",
+					"firstName": "System"
+				},
+				"description": "Updates existing SRS MARC Bib records based on Inventory single record imports",
+				"folioRecord": "MARC_BIBLIOGRAPHIC",
+				"childProfiles": [{
+						"id": "f90864ef-8030-480f-a43f-8cdd21233252",
+						"order": 0,
+						"content": {
+							"id": "f90864ef-8030-480f-a43f-8cdd21233252",
+							"name": "Update MARC Bib",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606726926555,
+								"updatedDate": 1606726926555,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "",
+							"childProfiles": [],
+							"mappingDetails": {
+								"name": "marcBib",
+								"recordType": "MARC_BIBLIOGRAPHIC",
+								"mappingFields": [],
+								"marcMappingOption": "UPDATE",
+								"marcMappingDetails": []
+							},
+							"parentProfiles": [],
+							"existingRecordType": "MARC_BIBLIOGRAPHIC",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+							"marcFieldProtectionSettings": []
+						},
+						"contentType": "MAPPING_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				],
+				"parentProfiles": [{
+						"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+						"order": 0,
+						"content": {
+							"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+							"name": "Inventory Single Record - Default match for existing SRS record",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727161520,
+								"updatedDate": 1606730341248,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "MARC_BIBLIOGRAPHIC",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+									"order": 0,
+									"content": {
+										"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+										"name": "March Profile by Instance UUID",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727217367,
+											"updatedDate": 1606729869001,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "INSTANCE",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "instance.id"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [{
+												"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+												"order": 0,
+												"content": {
+													"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+													"name": "Update instance",
+													"action": "UPDATE",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606726985334,
+														"updatedDate": 1606726985334,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"folioRecord": "INSTANCE",
+													"childProfiles": [],
+													"parentProfiles": []
+												},
+												"contentType": "ACTION_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"parentProfiles": [{
+												"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+												"order": 0,
+												"content": {
+													"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+													"name": "MARC-2-MARC",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606727161520,
+														"updatedDate": 1606727161520,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"matchDetails": [{
+															"matchCriterion": "EXACTLY_MATCHES",
+															"existingRecordType": "MARC_BIBLIOGRAPHIC",
+															"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+															"existingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															},
+															"incomingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															}
+														}
+													],
+													"childProfiles": [],
+													"parentProfiles": [],
+													"existingRecordType": "MARC_BIBLIOGRAPHIC",
+													"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+												},
+												"contentType": "MATCH_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"existingRecordType": "INSTANCE",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}, {
+									"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+									"order": 0,
+									"content": {
+										"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+										"name": "Update MARC Bib",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726959960,
+											"updatedDate": 1606726959960,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "MARC_BIBLIOGRAPHIC",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+									"order": 0,
+									"content": {
+										"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+										"name": "Inventory Single Record - Default Update Instance",
+										"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+										"deleted": false,
+										"hidden": false,
+										"dataType": "MARC",
+										"metadata": {
+											"createdDate": 1606727267667,
+											"updatedDate": 1606727350382,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "JOB_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "MARC_BIBLIOGRAPHIC",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}, {
+						"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+						"order": 0,
+						"content": {
+							"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+							"name": "Inventory Single Record - Default match for existing SRS record",
+							"deleted": false,
+							"hidden": false,
+							"metadata": {
+								"createdDate": 1606727161520,
+								"updatedDate": 1606730341248,
+								"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+								"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+							},
+							"userInfo": {
+								"lastName": "System",
+								"userName": "System",
+								"firstName": "System"
+							},
+							"description": "Matches the Instance UUID from the 999 ff $i in the incoming MARC record to the same field in any SRS MARC Bib",
+							"matchDetails": [{
+									"matchCriterion": "EXACTLY_MATCHES",
+									"existingRecordType": "MARC_BIBLIOGRAPHIC",
+									"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+									"existingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									},
+									"incomingMatchExpression": {
+										"fields": [{
+												"label": "field",
+												"value": "999"
+											}, {
+												"label": "indicator1",
+												"value": "f"
+											}, {
+												"label": "indicator2",
+												"value": "f"
+											}, {
+												"label": "recordSubfield",
+												"value": "i"
+											}
+										],
+										"dataValueType": "VALUE_FROM_RECORD"
+									}
+								}
+							],
+							"childProfiles": [{
+									"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+									"order": 0,
+									"content": {
+										"id": "31dbb554-0826-48ec-a0a4-3c55293d4dee",
+										"name": "March Profile by Instance UUID",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606727217367,
+											"updatedDate": 1606729869001,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"matchDetails": [{
+												"matchCriterion": "EXACTLY_MATCHES",
+												"existingRecordType": "INSTANCE",
+												"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+												"existingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "instance.id"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												},
+												"incomingMatchExpression": {
+													"fields": [{
+															"label": "field",
+															"value": "999"
+														}, {
+															"label": "indicator1",
+															"value": "f"
+														}, {
+															"label": "indicator2",
+															"value": "f"
+														}, {
+															"label": "recordSubfield",
+															"value": "i"
+														}
+													],
+													"dataValueType": "VALUE_FROM_RECORD"
+												}
+											}
+										],
+										"childProfiles": [{
+												"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+												"order": 0,
+												"content": {
+													"id": "cddff0e1-233c-47ba-8be5-553c632709d9",
+													"name": "Update instance",
+													"action": "UPDATE",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606726985334,
+														"updatedDate": 1606726985334,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"folioRecord": "INSTANCE",
+													"childProfiles": [],
+													"parentProfiles": []
+												},
+												"contentType": "ACTION_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"parentProfiles": [{
+												"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+												"order": 0,
+												"content": {
+													"id": "d27d71ce-8a1e-44c6-acea-96961b5592c6",
+													"name": "MARC-2-MARC",
+													"deleted": false,
+													"hidden": false,
+													"metadata": {
+														"createdDate": 1606727161520,
+														"updatedDate": 1606727161520,
+														"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+														"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+													},
+													"userInfo": {
+														"lastName": "System",
+														"userName": "System",
+														"firstName": "System"
+													},
+													"description": "",
+													"matchDetails": [{
+															"matchCriterion": "EXACTLY_MATCHES",
+															"existingRecordType": "MARC_BIBLIOGRAPHIC",
+															"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+															"existingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															},
+															"incomingMatchExpression": {
+																"fields": [{
+																		"label": "field",
+																		"value": "999"
+																	}, {
+																		"label": "indicator1",
+																		"value": "f"
+																	}, {
+																		"label": "indicator2",
+																		"value": "f"
+																	}, {
+																		"label": "recordSubfield",
+																		"value": "i"
+																	}
+																],
+																"dataValueType": "VALUE_FROM_RECORD"
+															}
+														}
+													],
+													"childProfiles": [],
+													"parentProfiles": [],
+													"existingRecordType": "MARC_BIBLIOGRAPHIC",
+													"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+												},
+												"contentType": "MATCH_PROFILE",
+												"childSnapshotWrappers": []
+											}
+										],
+										"existingRecordType": "INSTANCE",
+										"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+									},
+									"contentType": "MATCH_PROFILE",
+									"childSnapshotWrappers": []
+								}, {
+									"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+									"order": 0,
+									"content": {
+										"id": "6aa8e98b-0d9f-41dd-b26f-15658d07eb52",
+										"name": "Update MARC Bib",
+										"action": "UPDATE",
+										"deleted": false,
+										"hidden": false,
+										"metadata": {
+											"createdDate": 1606726959960,
+											"updatedDate": 1606726959960,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"description": "",
+										"folioRecord": "MARC_BIBLIOGRAPHIC",
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "ACTION_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"parentProfiles": [{
+									"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+									"order": 0,
+									"content": {
+										"id": "91f9b8d6-d80e-4727-9783-73fb53e3c786",
+										"name": "Inventory Single Record - Default Update Instance",
+										"description": "Triggered by an action in Inventory, this job profile imports a single record from an external system, to update an existing Instance, and either create a new MARC record or update an existing MARC record",
+										"deleted": false,
+										"hidden": false,
+										"dataType": "MARC",
+										"metadata": {
+											"createdDate": 1606727267667,
+											"updatedDate": 1606727350382,
+											"createdByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575",
+											"updatedByUserId": "6a010e5b-5421-5b1c-9b52-568b37038575"
+										},
+										"userInfo": {
+											"lastName": "System",
+											"userName": "System",
+											"firstName": "System"
+										},
+										"childProfiles": [],
+										"parentProfiles": []
+									},
+									"contentType": "JOB_PROFILE",
+									"childSnapshotWrappers": []
+								}
+							],
+							"existingRecordType": "MARC_BIBLIOGRAPHIC",
+							"incomingRecordType": "MARC_BIBLIOGRAPHIC"
+						},
+						"contentType": "MATCH_PROFILE",
+						"childSnapshotWrappers": []
+					}
+				]
+			},
+			"contentType": "ACTION_PROFILE",
+			"childSnapshotWrappers": []
+		}
+	],
+	"existingRecordType": "MARC_BIBLIOGRAPHIC",
+	"incomingRecordType": "MARC_BIBLIOGRAPHIC",
+	"marcFieldProtectionSettings": []
+}'
+WHERE id = 'f90864ef-8030-480f-a43f-8cdd21233252';

--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_qm_holdings_and_srs_marc_holdings_create_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_qm_holdings_and_srs_marc_holdings_create_job_profile.sql
@@ -4,6 +4,7 @@ SET jsonb =  '{
   "name": "quickMARC - Create Holdings and SRS MARC Holdings",
   "description": "This job profile is used by the quickMARC to allow a user to create a new SRS MARC holdings record and corresponding Inventory holdings. Profile cannot be edited or deleted",
   "deleted": false,
+  "hidden": false,
   "dataType": "MARC",
   "tags": {
     "tagList": []
@@ -24,11 +25,37 @@ SET jsonb =  '{
 }'
 WHERE id = 'fa0262c7-5816-48d0-b9b3-7b7a862a5bc7';
 
+UPDATE ${myuniversity}_${mymodule}.action_profiles
+SET jsonb =  '{
+  "id": "f5feddba-f892-4fad-b702-e4e77f04f9a3",
+  "name": "quickMARC Derive - Create Inventory Holdings",
+  "action": "CREATE",
+  "deleted": false,
+  "hidden": false,
+  "description": "This action profile is used with FOLIO''s default job profile for creating Inventory Holdings and SRS MARC Holdings records. It cannot be edited or deleted.",
+  "folioRecord": "HOLDINGS",
+  "childProfiles": [],
+  "parentProfiles": [],
+    "metadata": {
+      "createdDate": "2021-08-05T14:00:00.000",
+      "updatedDate": "2021-08-05T15:00:00.462+0000",
+      "createdByUserId": "00000000-0000-0000-0000-000000000000",
+      "updatedByUserId": "00000000-0000-0000-0000-000000000000"
+    },
+    "userInfo": {
+      "lastName": "System",
+      "userName": "System",
+      "firstName": "System"
+    }
+}'
+WHERE id = 'f5feddba-f892-4fad-b702-e4e77f04f9a3';
+
 UPDATE ${myuniversity}_${mymodule}.mapping_profiles
 SET jsonb =  '{
   "id": "e0fbaad5-10c0-40d5-9228-498b351dbbaa",
   "name": "quickMARC - Create MARC holdings and Inventory holdings",
   "deleted": false,
+  "hidden": false,
   "metadata": {
     "createdDate": "2021-08-05T14:00:00.000",
     "updatedDate": "2021-08-05T15:00:00.462+0000",

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/ActionProfileTest.java
@@ -111,7 +111,8 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("actionProfiles*.deleted", everyItem(is(false)));
+      .body("actionProfiles*.deleted", everyItem(is(false)))
+      .body("actionProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test
@@ -125,6 +126,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
       .body("actionProfiles*.deleted", everyItem(is(false)))
+      .body("actionProfiles*.hidden", everyItem(is(false)))
       .body("actionProfiles*.userInfo.lastName", everyItem(is("Doe")));
   }
 
@@ -139,6 +141,7 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(2))
       .body("actionProfiles*.deleted", everyItem(is(false)))
+      .body("actionProfiles*.hidden", everyItem(is(false)))
       .body("actionProfiles.get(0).tags.tagList", hasItem("ipsum"))
       .body("actionProfiles.get(1).tags.tagList", hasItem("ipsum"));
   }
@@ -560,7 +563,8 @@ public class ActionProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("actionProfiles*.deleted", everyItem(is(false)));
+      .body("actionProfiles*.deleted", everyItem(is(false)))
+      .body("actionProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
@@ -31,6 +31,17 @@ public class DefaultJobProfileTest extends AbstractRestVerticleTest {
   }
 
   @Test
+  public void shouldReturnWithHiddenProfilesOnGet() {
+    RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(JOB_PROFILES_PATH + "?showHidden=true")
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("totalRecords", is(7));
+  }
+
+  @Test
   public void shouldReturnMarcAuthorityProfileOnGetById() {
     final var profile = RestAssured.given()
       .spec(spec)

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/JobProfileTest.java
@@ -108,7 +108,8 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("jobProfiles*.deleted", everyItem(is(false)));
+      .body("jobProfiles*.deleted", everyItem(is(false)))
+      .body("jobProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test
@@ -122,6 +123,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
       .body("jobProfiles*.deleted", everyItem(is(false)))
+      .body("jobProfiles*.hidden", everyItem(is(false)))
       .body("jobProfiles*.userInfo.lastName", everyItem(is("Doe")));
   }
 
@@ -136,6 +138,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(2))
       .body("jobProfiles*.deleted", everyItem(is(false)))
+      .body("jobProfiles*.hidden", everyItem(is(false)))
       .body("jobProfiles.get(0).tags.tagList", hasItem("ipsum"))
       .body("jobProfiles.get(1).tags.tagList", hasItem("ipsum"));
   }
@@ -151,6 +154,7 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("jobProfiles.size()", is(2))
       .body("jobProfiles*.deleted", everyItem(is(false)))
+      .body("jobProfiles*.hidden", everyItem(is(false)))
       .body("totalRecords", is(3));
   }
 
@@ -606,7 +610,8 @@ public class JobProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("jobProfiles*.deleted", everyItem(is(false)));
+      .body("jobProfiles*.deleted", everyItem(is(false)))
+      .body("jobProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/MappingProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/MappingProfileTest.java
@@ -154,7 +154,8 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("mappingProfiles*.deleted", everyItem(is(false)));
+      .body("mappingProfiles*.deleted", everyItem(is(false)))
+      .body("mappingProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test
@@ -575,7 +576,8 @@ public class MappingProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("mappingProfiles*.deleted", everyItem(is(false)));
+      .body("mappingProfiles*.deleted", everyItem(is(false)))
+      .body("mappingProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/MatchProfileTest.java
@@ -105,7 +105,8 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("matchProfiles*.deleted", everyItem(is(false)));
+      .body("matchProfiles*.deleted", everyItem(is(false)))
+      .body("matchProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test
@@ -122,7 +123,8 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
       .body("totalRecords", is(1))
       .body("matchProfiles*.childProfiles*.id", everyItem(is(notNullValue())))
       .body("matchProfiles*.parentProfiles*.id", everyItem(is(notNullValue())))
-      .body("matchProfiles*.deleted", everyItem(is(false)));
+      .body("matchProfiles*.deleted", everyItem(is(false)))
+      .body("matchProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test
@@ -152,6 +154,7 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
       .body("matchProfiles*.deleted", everyItem(is(false)))
+      .body("matchProfiles*.hidden", everyItem(is(false)))
       .body("matchProfiles*.userInfo.lastName", everyItem(is("Doe")));
   }
 
@@ -593,7 +596,8 @@ public class MatchProfileTest extends AbstractRestVerticleTest {
       .then()
       .statusCode(HttpStatus.SC_OK)
       .body("totalRecords", is(3))
-      .body("matchProfiles*.deleted", everyItem(is(false)));
+      .body("matchProfiles*.deleted", everyItem(is(false)))
+      .body("matchProfiles*.hidden", everyItem(is(false)));
   }
 
   @Test

--- a/ramls/data-import-converter-storage.raml
+++ b/ramls/data-import-converter-storage.raml
@@ -63,6 +63,12 @@ resourceTypes:
           type: boolean
           default: false
           required: false
+        showHidden:
+          description: selection condition of Job Profiles by field 'hidden'
+          example: false
+          type: boolean
+          default: false
+          required: false
         withRelations:
           description: Load profile with related child and parent profiles
           example: false
@@ -125,6 +131,12 @@ resourceTypes:
       queryParameters:
         showDeleted:
           description: selection condition of Match Profiles by field 'deleted'
+          example: false
+          type: boolean
+          default: false
+          required: false
+        showHidden:
+          description: selection condition of Match Profiles by field 'hidden'
           example: false
           type: boolean
           default: false
@@ -195,6 +207,12 @@ resourceTypes:
           type: boolean
           default: false
           required: false
+        showHidden:
+          description: selection condition of Mapping Profiles by field 'hidden'
+          example: false
+          type: boolean
+          default: false
+          required: false
         withRelations:
           description: Load profile with related child and parent profiles
           example: false
@@ -257,6 +275,12 @@ resourceTypes:
       queryParameters:
         showDeleted:
           description: selection condition of Action Profiles by field 'deleted'
+          example: false
+          type: boolean
+          default: false
+          required: false
+        showHidden:
+          description: selection condition of Action Profiles by field 'hidden'
           example: false
           type: boolean
           default: false


### PR DESCRIPTION
## Purpose
Make MARC Authority Delete profiles hidden

## Approach
- Check if any migration scripts needed for other profiles
- Add new query parameter for endpoints:
   * query parameter requirements:
       * name: showHidden
       * type: boolean
       * required: false
       * default: false
   * endpoints to update:
       * GET /data-import-profiles/jobProfiles
       * GET /data-import-profiles/matchProfiles
       * GET /data-import-profiles/mappingProfiles
       * GET /data-import-profiles/actionProfiles

- Add tests to check this query parameter in updated endpoints

## Learning
[https://issues.folio.org/browse/MODDICONV-234](MODDICONV-234)
