### PR TITLE
MODDATAIMP-635 Check if any 3d party dependencies should be update for DI modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.6</raml-module-builder.version>
-    <vertx.version>4.2.5</vertx.version>
+    <raml-module-builder.version>33.2.2</raml-module-builder.version>
+    <vertx.version>4.2.1</vertx.version>
     <junit.version>4.13</junit.version>
     <mockito.version>3.5.13</mockito.version>
     <rest-assured.version>4.3.3</rest-assured.version>
@@ -33,6 +33,13 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,8 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.2</raml-module-builder.version>
-    <vertx.version>4.2.1</vertx.version>
+    <raml-module-builder.version>33.2.6</raml-module-builder.version>
+    <vertx.version>4.2.5</vertx.version>
     <junit.version>4.13</junit.version>
     <mockito.version>3.5.13</mockito.version>
     <rest-assured.version>4.3.3</rest-assured.version>


### PR DESCRIPTION
## Purpose
Using the latest versions helps us avoid possible problems with the libraries.

## Approach

- Overidded log4j for fix critic vulnarebility to 2.17.0 version

## TODO

- Create a task to upgrade the rmb and vertx dependencies for Morning Glory

## Learning
[MODDATAIMP-635](https://issues.folio.org/browse/MODDATAIMP-635)
