### PR TITLE
MODDICONV-235 Adding a tag to some profiles displays an error message and a success message

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
-## 2021-02-24 v1.13.0
+## 2022-XX-XX v1.14.0-SNAPSHOT
+* [MODDICONV-235](https://issues.folio.org/browse/MODDICONV-235) Adding a tag to some profiles displays an error message and a success message
+
+## 2022-02-24 v1.13.0
 * [MODDICONV-211](https://issues.folio.org/browse/MODDICONV-211) Settings : Updates to default job profiles
 * [MODDICONV-215](https://issues.folio.org/browse/MODDICONV-215) Upgrade to RMB 33.2.2 (includes fix of log4j vulnerability)
 

--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/services/ProfileService.java
@@ -74,6 +74,17 @@ public interface ProfileService<T, S, D> {
   Future<Boolean> isProfileExistByProfileId(T profile, String tenantId);
 
   /**
+   * Check profile to access another fields except tags
+   *
+   * @param id               - Profile id
+   * @param profile          - D DTO
+   * @param isDefaultProfile - True if the profile lists as default
+   * @param tenantId         - Tenant id from request
+   * @return - boolean value. True if in the profile DTO has been changed only Tags
+   */
+  Future<Boolean> isProfileDtoValidForUpdate(String id, D profile, boolean isDefaultProfile, String tenantId);
+
+  /**
    * Marks profile as deleted by its id
    *
    * @param id       Profile id

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultActionProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultActionProfileTest.java
@@ -1,0 +1,57 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.ActionProfile;
+import org.folio.rest.jaxrs.model.ActionProfileUpdateDto;
+import org.folio.rest.jaxrs.model.Tags;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.folio.rest.impl.ActionProfileTest.ACTION_PROFILES_PATH;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultActionProfileTest extends AbstractRestVerticleTest {
+
+  private static final String DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID = "7915c72e-c6af-4962-969d-403c7238b051";
+
+  @Test
+  public void shouldAddAndRemoveTagsDefaultProfile() {
+    Tags tags = new Tags().withTagList(Arrays.asList("Lorem", "ipsum"));
+    var profile = getActionProfileById(DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID);
+//    Add tags to default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new ActionProfileUpdateDto().withProfile(profile.withTags(tags)))
+      .when()
+      .put(ACTION_PROFILES_PATH + "/" + DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(tags.getTagList()));
+
+    profile = getActionProfileById(DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID);
+//    Delete tags from default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new ActionProfileUpdateDto().withProfile(profile.withTags(new Tags().withTagList(Collections.emptyList()))))
+      .when()
+      .put(ACTION_PROFILES_PATH + "/" + DEFAULT_CREATE_AUTHORITIES_ACTION_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(Matchers.empty()));
+  }
+
+  private ActionProfile getActionProfileById(String id) {
+    return RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(ACTION_PROFILES_PATH + "/" + id)
+      .then().extract().as(ActionProfile.class);
+  }
+}

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultJobProfileTest.java
@@ -3,10 +3,17 @@ package org.folio.rest.impl;
 import io.restassured.RestAssured;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.Tags;
 import org.folio.rest.jaxrs.model.JobProfile;
+import org.folio.rest.jaxrs.model.JobProfileUpdateDto;
+import org.hamcrest.Matchers;
+import org.hamcrest.core.Is;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
 
 import static org.folio.rest.impl.JobProfileTest.JOB_PROFILES_PATH;
 import static org.hamcrest.Matchers.is;
@@ -64,6 +71,40 @@ public class DefaultJobProfileTest extends AbstractRestVerticleTest {
       .statusCode(HttpStatus.SC_OK).extract().as(JobProfile.class);
     Assert.assertEquals( "quickMARC - Create Holdings and SRS MARC Holdings", profile.getName());
     Assert.assertEquals( JobProfile.DataType.MARC, profile.getDataType());
+  }
+
+  @Test
+  public void shouldAddAndRemoveTagsDefaultProfile() {
+    Tags tags = new Tags().withTagList(Arrays.asList("Lorem", "ipsum"));
+    var profile = getJobProfileById(DEFAULT_MARC_AUTHORITY_PROFILE_ID);
+//    Add tags to default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileUpdateDto().withProfile(profile.withTags(tags)))
+      .when()
+      .put(JOB_PROFILES_PATH + "/" + DEFAULT_MARC_AUTHORITY_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", Is.is(tags.getTagList()));
+
+    profile = getJobProfileById(DEFAULT_MARC_AUTHORITY_PROFILE_ID);
+//    Delete tags from default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new JobProfileUpdateDto().withProfile(profile.withTags(new Tags().withTagList(Collections.emptyList()))))
+      .when()
+      .put(JOB_PROFILES_PATH + "/" + DEFAULT_MARC_AUTHORITY_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", Is.is(Matchers.empty()));
+  }
+
+  private JobProfile getJobProfileById(String id) {
+    return RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(JOB_PROFILES_PATH + "/" + id)
+      .then().extract().as(JobProfile.class);
   }
 
 }

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMappingProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMappingProfileTest.java
@@ -1,0 +1,56 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.Tags;
+import org.folio.rest.jaxrs.model.MappingProfile;
+import org.folio.rest.jaxrs.model.MappingProfileUpdateDto;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.folio.rest.impl.MappingProfileTest.MAPPING_PROFILES_PATH;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultMappingProfileTest extends AbstractRestVerticleTest  {
+
+  private static final String DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID = "6a0ec1de-68eb-4833-bdbf-0741db25c314";
+  @Test
+  public void shouldAddAndRemoveTagsDefaultProfile() {
+    Tags tags = new Tags().withTagList(Arrays.asList("Lorem", "ipsum"));
+    var profile = getMappingProfileById(DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID);
+//    Add tags to default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new MappingProfileUpdateDto().withProfile(profile.withTags(tags)))
+      .when()
+      .put(MAPPING_PROFILES_PATH + "/" + DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(tags.getTagList()));
+
+    profile = getMappingProfileById(DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID);
+//    Delete tags from default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new MappingProfileUpdateDto().withProfile(profile.withTags(new Tags().withTagList(Collections.emptyList()))))
+      .when()
+      .put(MAPPING_PROFILES_PATH + "/" + DEFAULT_CREATE_AUTHORITIES_MAPPING_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(Matchers.empty()));
+  }
+
+  private MappingProfile getMappingProfileById(String id) {
+    return RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(MAPPING_PROFILES_PATH + "/" + id)
+      .then().extract().as(MappingProfile.class);
+  }
+}

--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/DefaultMatchProfileTest.java
@@ -1,0 +1,57 @@
+package org.folio.rest.impl;
+
+import io.restassured.RestAssured;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.apache.http.HttpStatus;
+import org.folio.rest.jaxrs.model.Tags;
+import org.folio.rest.jaxrs.model.MatchProfile;
+import org.folio.rest.jaxrs.model.MatchProfileUpdateDto;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.folio.rest.impl.MatchProfileTest.MATCH_PROFILES_PATH;
+import static org.hamcrest.core.Is.is;
+
+@RunWith(VertxUnitRunner.class)
+public class DefaultMatchProfileTest extends AbstractRestVerticleTest{
+
+  private static final String OCLC_INSTANCE_UUID_MATCH_PROFILE_ID = "31dbb554-0826-48ec-a0a4-3c55293d4dee";
+
+  @Test
+  public void shouldAddAndRemoveTagsDefaultProfile() {
+    Tags tags = new Tags().withTagList(Arrays.asList("Lorem", "ipsum"));
+    var profile = getMappingProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
+//    Add tags to default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new MatchProfileUpdateDto().withProfile(profile.withTags(tags)))
+      .when()
+      .put(MATCH_PROFILES_PATH + "/" + OCLC_INSTANCE_UUID_MATCH_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(tags.getTagList()));
+
+    profile = getMappingProfileById(OCLC_INSTANCE_UUID_MATCH_PROFILE_ID);
+//    Delete tags from default profile
+    RestAssured.given()
+      .spec(spec)
+      .body(new MatchProfileUpdateDto().withProfile(profile.withTags(new Tags().withTagList(Collections.emptyList()))))
+      .when()
+      .put(MATCH_PROFILES_PATH + "/" + OCLC_INSTANCE_UUID_MATCH_PROFILE_ID)
+      .then()
+      .statusCode(HttpStatus.SC_OK)
+      .body("tags.tagList", is(Matchers.empty()));
+  }
+
+  private MatchProfile getMappingProfileById(String id) {
+    return RestAssured.given()
+      .spec(spec)
+      .when()
+      .get(MATCH_PROFILES_PATH + "/" + id)
+      .then().extract().as(MatchProfile.class);
+  }
+}


### PR DESCRIPTION
## Purpose
Tag doesn't attach to default DI profiles

## Approach
- Compare entity with profile from database, exclude metadata and tags to avoid update other properties default profile except tags.

#### TODOS and Open Questions
- Implement updating single property using http patch method to prevent using put as in this case.

## Learning
[MODDICONV-235](https://issues.folio.org/browse/MODDICONV-235)
