### PR TITLE
MODDICONV-239 FOLIO-3231 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,10 @@
 buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
-  publishAPI = 'yes'
   buildNode = 'jenkins-agent-java11'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,8 +2,11 @@ buildMvn {
   publishModDescriptor = 'yes'
   mvnDeploy = 'yes'
   publishAPI = 'yes'
-  runLintRamlCop = 'yes'
   buildNode = 'jenkins-agent-java11'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   doDocker = {
     buildJavaDocker {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-data-import-converter-storage
 
-Copyright (C) 2019 The Open Library Foundation
+Copyright (C) 2019-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License, Version 2.0.
 See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/

The https://dev.folio.org/reference/api/#mod-data-import-converter-storage section of API documentation will be automatically reconfigured:
https://dev.folio.org/reference/api/#explain-gather-config

### TODO:
Please fix the JSON errors, as described in the subsequent comment.
