### PR TITLE
Update dependencies fixing CVE-2020-36518, CVE-2021-43797

### DIFF
--- a/mod-data-import-converter-storage-server/pom.xml
+++ b/mod-data-import-converter-storage-server/pom.xml
@@ -11,7 +11,7 @@
   <properties>
     <basedir>${project.parent.basedir}</basedir>
     <ramlfiles_path>${project.parent.basedir}/ramls</ramlfiles_path>
-    <wiremock.version>2.19.0</wiremock.version>
+    <wiremock.version>2.32.0</wiremock.version>
   </properties>
 
   <dependencies>
@@ -67,7 +67,7 @@
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
-      <artifactId>wiremock</artifactId>
+      <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>
       <scope>test</scope>
       <exclusions>

--- a/pom.xml
+++ b/pom.xml
@@ -19,16 +19,16 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>33.2.2</raml-module-builder.version>
-    <vertx.version>4.2.1</vertx.version>
-    <junit.version>4.13</junit.version>
-    <mockito.version>3.5.13</mockito.version>
-    <rest-assured.version>4.3.3</rest-assured.version>
+    <raml-module-builder.version>33.2.8</raml-module-builder.version>
+    <vertx.version>4.2.6</vertx.version>
+    <junit.version>4.13.2</junit.version>
+    <mockito.version>4.4.0</mockito.version>
+    <rest-assured.version>4.5.1</rest-assured.version>
     <main.basedir>${project.basedir}</main.basedir>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
-    <testcontainers.version>1.15.3</testcontainers.version>
+    <testcontainers.version>1.16.3</testcontainers.version>
   </properties>
 
   <dependencyManagement>
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Update RMB from 33.2.2 to 33.2.8.

The RMB update indirectly updates jackson-databind from 2.11.4 to 2.13.2.1 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Update Vert.x from 4.2.1 to 4.2.6.

The Vert.x update indirectly updates Netty from 4.1.69.Final to 4.1.74.Final fixing https://nvd.nist.gov/vuln/detail/CVE-2021-43797

Update log4j from 2.17.0 to 2.17.2 fixing https://nvd.nist.gov/vuln/detail/CVE-2021-44832

Update junit from 4.13 to 4.13.2 fixing https://nvd.nist.gov/vuln/detail/CVE-2020-15250

Update wiremock from 2.19.0 to 2.32.0.

Update mockito from 3.5.13 to 4.4.0.

Update rest-assured from 4.3.3 to 4.5.1.

Update testcontainers from 1.15.3 to 1.16.3.