### PR TITLE
MODDICONV-254 Cache job profile snapshots

### DIFF
--- a/mod-data-import-converter-storage-server/pom.xml
+++ b/mod-data-import-converter-storage-server/pom.xml
@@ -66,6 +66,11 @@
       <type>jar</type>
     </dependency>
     <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.8.5</version>
+    </dependency>
+    <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock-jre8</artifactId>
       <version>${wiremock.version}</version>


### PR DESCRIPTION
## Purpose
Get performance gains by caching job profile snapshots

## Approach
Once profile snapshots are created, they are never updated. Also, it is retrieved multiple times by actors in the data import system that it makes sense to reduce the response time of this endpoint.


## Learning
https://issues.folio.org/browse/MODDICONV-254
