### PR TITLE
MODDICONV-260: spring-beans 5.3.20, Vert.x 4.3.3 fixing vulns

### DIFF
--- a/mod-data-import-converter-storage-server/pom.xml
+++ b/mod-data-import-converter-storage-server/pom.xml
@@ -62,7 +62,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-di-support</artifactId>
-      <version>1.4.1</version>
+      <version>1.6.0</version>
       <type>jar</type>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
   <properties>
     <raml-module-builder.version>34.1.0</raml-module-builder.version>
-    <vertx.version>4.3.1</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.4.0</mockito.version>
     <rest-assured.version>4.5.1</rest-assured.version>


### PR DESCRIPTION
Upgrade folio-di-support from 1.4.1 to 1.6.0.

This indirectly upgrades Spring and spring-beans from 5.2.8 to 5.3.20 fixing Remote Code Execution: https://nvd.nist.gov/vuln/detail/CVE-2022-22965

Upgrade Vert.x from 4.3.1 to 4.3.3 fixing SSL in WebClient: https://github.com/vert-x3/wiki/wiki/4.3.2-Release-Notes#vertx-web