### PR TITLE
MODDICONV-269: Change registration module in tests

### DIFF
--- a/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
+++ b/mod-data-import-converter-storage-server/src/test/java/org/folio/rest/impl/AbstractRestVerticleTest.java
@@ -89,7 +89,7 @@ public abstract class AbstractRestVerticleTest {
     vertx.deployVerticle(RestVerticle.class.getName(), restVerticleDeploymentOptions, res -> {
       try {
         TenantAttributes tenantAttributes = new TenantAttributes();
-        tenantAttributes.setModuleTo(ModuleName.getModuleName());
+        tenantAttributes.setModuleTo(ModuleName.getModuleName() + "-1.0.0");
         tenantClient.postTenant(tenantAttributes, res2 -> {
           if (res2.result().statusCode() == 204) {
             return;

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   </modules>
 
   <properties>
-    <raml-module-builder.version>35.0.0</raml-module-builder.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
     <vertx.version>4.3.3</vertx.version>
     <junit.version>4.13.2</junit.version>
     <mockito.version>4.4.0</mockito.version>


### PR DESCRIPTION
According to changes in RMB 35.0.0.0 [RMB-937](https://issues.folio.org/browse/RMB-937) add version "1.0.0" when registering the module in AbstractRestVerticleTest

## Learning
[MODDICONV-269](https://issues.folio.org/browse/MODDICONV-269)