### PR TITLE
MODDICONV-270 Data import job profiles created prior to morning glory are hidden

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/AbstractProfileDao.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/dao/AbstractProfileDao.java
@@ -53,7 +53,7 @@ public abstract class AbstractProfileDao<T, S> implements ProfileDao<T, S> {
         cql.addWrapper(getCQLWrapper(getTableName(), notDeletedProfilesFilter));
       }
       if (!showHidden) {
-        var notHiddenProfilesFilter = "hidden==false";
+        var notHiddenProfilesFilter = "cql.allRecords=1 NOT hidden == true";
         cql.addWrapper(getCQLWrapper(getTableName(), notHiddenProfilesFilter));
       }
       pgClientFactory.createInstance(tenantId).get(getTableName(), getProfileType(), fieldList, cql, true, false, promise);


### PR DESCRIPTION
## Purpose
Show profiles created before MG

## Approach
- change cql query to avoid hidden 'true' instead of searching for 'false'

## Learning
[MODDICONV-270](https://issues.folio.org/browse/MODDICONV-270)
[Cql matching](https://github.com/folio-org/raml-module-builder/blob/master/README.md#cql-matching-undefined-or-empty-values)
