### PR TITLE
MODDICONV-270 Data import job profiles created prior to morning glory are hidden

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -221,7 +221,7 @@
     {
       "run": "after",
       "snippetPath": "data-migration/set_deleted_hidden_defaults.sql",
-      "fromModuleVersion": "mod-data-import-converter-storage-1.15.1"
+      "fromModuleVersion": "mod-data-import-converter-storage-1.14.2"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
downgrade "fromModuleVersion" for `set_deleted_hidden_defaults.sql` script as it's included in MG hotfix

## Learning
[MODDICONV-270](https://issues.folio.org/browse/MODDICONV-270)
