### PR TITLE
MODDICONV-279: Spring 5.2.22 fixing vulnerabilities (Spring4Shell, etc.) MG

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <sonar.exclusions>**/ModTenantAPI.java</sonar.exclusions>
+    <spring-framework.version>5.2.22.RELEASE</spring-framework.version>
     <testcontainers.version>1.16.3</testcontainers.version>
   </properties>
 
@@ -44,6 +45,13 @@
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>${vertx.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-framework-bom</artifactId>
+        <version>${spring-framework.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
For 2022 R2 Morning Glory Hot Fix:

Upgrade Spring Framework from 5.2.8.RELEASE to 5.2.22.RELEASE.

The Spring upgrade upgrades spring-beans fixing Spring4Shell Remote Code Execution and Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-22965
https://nvd.nist.gov/vuln/detail/CVE-2022-22970

The Spring upgrade upgrades spring-context fixing Improper Handling of Case Sensitivity:
https://nvd.nist.gov/vuln/detail/CVE-2022-22968

The Spring upgrade upgrades spring-expression fixing Denial of Service (DoS):
https://nvd.nist.gov/vuln/detail/CVE-2022-22950

The Spring upgrade upgrades spring-core fixing Improper Input Validation and Improper Output Neutralization for Logs:
https://nvd.nist.gov/vuln/detail/CVE-2021-22060
https://nvd.nist.gov/vuln/detail/CVE-2021-22096