### PR TITLE
[MODDATAIMP-736] Adjust logging configuration to display datetime in a proper format

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/resources/log4j2.properties
+++ b/mod-data-import-converter-storage-server/src/main/resources/log4j2.properties
@@ -1,29 +1,12 @@
 appenders = console
 
+packages = org.folio.okapi.common.logging
+
 appender.console.type = Console
 appender.console.name = STDOUT
-appender.console.layout.type = JSONLayout
-appender.console.layout.compact = true
-appender.console.layout.eventEol = true
-appender.console.layout.stacktraceAsString = true
 
-## Folio fields (can be used after implementation of RMB-709)
-packages = org.folio.okapi.common.logging
-appender.console.layout.requestId.type = KeyValuePair
-appender.console.layout.requestId.key = requestId
-appender.console.layout.requestId.value = $${FolioLoggingContext:requestid}
-
-appender.console.layout.tenantId.type = KeyValuePair
-appender.console.layout.tenantId.key = tenantId
-appender.console.layout.tenantId.value = $${FolioLoggingContext:tenantid}
-
-appender.console.layout.userId.type = KeyValuePair
-appender.console.layout.userId.key = userId
-appender.console.layout.userId.value = $${FolioLoggingContext:userid}
-
-appender.console.layout.moduleId.type = KeyValuePair
-appender.console.layout.moduleId.key = moduleId
-appender.console.layout.moduleId.value = $${FolioLoggingContext:moduleid}
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss.SSS} [%t] [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info

--- a/mod-data-import-converter-storage-server/src/test/resources/log4j2-test.properties
+++ b/mod-data-import-converter-storage-server/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Purpose
Adjust logging configuration to display datetime in a proper format

## Approach
Changed logs config file
