### PR TITLE
MODDICONV-281 - Enable ability to edit Job profile: Default - Create SRS MARC Authority

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
+++ b/mod-data-import-converter-storage-server/src/main/java/org/folio/rest/impl/DataImportProfilesImpl.java
@@ -66,7 +66,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
   private static final String MASTER_PROFILE_NOT_FOUND_MSG = "Master profile with id '%s' was not found";
   private static final String DETAIL_PROFILE_NOT_FOUND_MSG = "Detail profile with id '%s' was not found";
   private static final String INVALID_REPEATABLE_FIELD_ACTION_FOR_EMPTY_SUBFIELDS_MESSAGE = "Invalid repeatableFieldAction for empty subfields: %s";
-
+  private static final String DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID = "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3";
   private static final String[] MATCH_PROFILES = {
     "d27d71ce-8a1e-44c6-acea-96961b5592c6", //OCLC_MARC_MARC_MATCH_PROFILE_ID
     "31dbb554-0826-48ec-a0a4-3c55293d4dee", //OCLC_INSTANCE_UUID_MATCH_PROFILE_ID
@@ -81,7 +81,6 @@ public class DataImportProfilesImpl implements DataImportProfiles {
     "fa0262c7-5816-48d0-b9b3-7b7a862a5bc7", //DEFAULT_CREATE_DERIVE_HOLDINGS_JOB_PROFILE_ID
     "6409dcff-71fa-433a-bc6a-e70ad38a9604", //DEFAULT_CREATE_DERIVE_INSTANCE_JOB_PROFILE_ID
     "80898dee-449f-44dd-9c8e-37d5eb469b1d", //DEFAULT_CREATE_HOLDINGS_AND_SRS_MARC_HOLDINGS_JOB_PROFILE_ID
-    "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3", //DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID
     "1a338fcd-3efc-4a03-b007-394eeb0d5fb9", //DEFAULT_DELETE_MARC_AUTHORITY_JOB_PROFILE_ID
     "cf6f2718-5aa5-482a-bba5-5bc9b75614da", //DEFAULT_QM_MARC_BIB_UPDATE_JOB_PROFILE_ID
     "6cb347c6-c0b0-4363-89fc-32cedede87ba", //DEFAULT_QM_HOLDINGS_UPDATE_JOB_PROFILE_ID
@@ -230,7 +229,7 @@ public class DataImportProfilesImpl implements DataImportProfiles {
                                                       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
-        if (canDeleteOrUpdateProfile(id, JOB_PROFILES)) {
+        if (isDefaultJobProfile(id)) {
           logger.error("Can`t delete default OCLC Job Profile with id {}", id);
           asyncResultHandler.handle(Future.succeededFuture(ExceptionHelper.mapExceptionToResponse(new BadRequestException("Can`t delete default OCLC Job Profile with"))));
         } else {
@@ -917,6 +916,10 @@ public class DataImportProfilesImpl implements DataImportProfiles {
 
   private boolean canDeleteOrUpdateProfile(String id, String... uids) {
     return Arrays.asList(uids).contains(id);
+  }
+
+  private boolean isDefaultJobProfile(String id) {
+    return DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID.equals(id) || Arrays.asList(JOB_PROFILES).contains(id);
   }
 
 }


### PR DESCRIPTION
## Purpose
_The "400" error appears when user tries to save edited "Default - Create SRS MARC Authority" job profile with the one of the following updated fields:
a) "Name*" or "Accepted data type*" or "Description";
b) "Name*" and "Accepted data type*" and "Description";_

## Approach
_ DEFAULT_CREATE_SRS_MARC_AUTHORITY_JOB_PROFILE_ID should be skipped during update request_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
https://issues.folio.org/browse/MODDICONV-281 
and more detailed in https://issues.folio.org/browse/UIDATIMP-1318
