### PR TITLE
MODDICONV-282 - Change Job profile: Default - Create SRS MARC Authority description

### DIFF
--- a/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_authority_job_profile.sql
+++ b/mod-data-import-converter-storage-server/src/main/resources/templates/db_scripts/defaultData/default_update_marc_authority_job_profile.sql
@@ -2,7 +2,7 @@ UPDATE ${myuniversity}_${mymodule}.job_profiles
 SET jsonb =  '{
 	"id": "6eefa4c6-bbf7-4845-ad82-de7fc5abd0e3",
   "name": "Default - Create SRS MARC Authority",
-  "description": "Default job profile for creating MARC authority records. These records are stored in source record storage (SRS). Profile cannot be edited or deleted",
+  "description": "Default job profile for creating MARC authority records. These records are stored in source record storage (SRS). Profile cannot be deleted",
   "deleted": false,
   "hidden": false,
   "dataType": "MARC",


### PR DESCRIPTION
## Purpose
_Change: Create SRS MARC Authority Job profile description to "Default job profile for creating MARC authority records. These records are stored in source record storage (SRS). Profile cannot be deleted."_

## Approach
_update sql script_

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
https://issues.folio.org/browse/MODDICONV-282 
and https://issues.folio.org/browse/UIDATIMP-1318